### PR TITLE
Release 2021.2.0 for MKL and 2021.2.2 for DAL

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -263,13 +263,20 @@ outputs:
         - tbb {{ daal_version.split('.')[0] }}.*
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
-      summary: DAL runtime libraries
+      summary: Intel® oneDAL runtime libraries
+      description: |
+        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+        optimized building blocks covering all stages of data analytics: data acquisition from a data
+        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
       license: Intel Simplified Software License
       license_family: Proprietary
-      license_file: mkl/info/licenses/license.txt
+      license_file:
+         - dal/info/licenses/license.txt
+         - dal/info/licenses/tpp.txt
       license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-      dev_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://github.com/oneapi-src/oneDAL
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -283,13 +290,20 @@ outputs:
       skip: True                                  # [win32]
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
-      summary: Headers for building against DAL libraries
+      summary: Headers for building against Intel® oneDAL libraries
+      description: |
+        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+        optimized building blocks covering all stages of data analytics: data acquisition from a data
+        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
       license: Intel Simplified Software License
       license_family: Proprietary
-      license_file: mkl/info/licenses/license.txt
+      license_file:
+         - dal-include/info/licenses/license.txt
+         - dal-include/info/licenses/tpp.txt
       license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-      dev_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://github.com/oneapi-src/oneDAL
     test:
       commands:
         - ls -A $PREFIX/include/*  # [unix]
@@ -307,13 +321,20 @@ outputs:
         - tbb {{ daal_version.split('.')[0] }}.*
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
-      summary: Static libraries for DAL
+      summary: Static libraries for Intel® oneDAL
+      description: |
+        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+        optimized building blocks covering all stages of data analytics: data acquisition from a data
+        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
       license: Intel Simplified Software License
       license_family: Proprietary
-      license_file: mkl/info/licenses/license.txt
+      license_file:
+         - dal-static/info/licenses/license.txt
+         - dal-static/info/licenses/tpp.txt
       license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-      dev_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://github.com/oneapi-src/oneDAL
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -333,13 +354,20 @@ outputs:
         - {{ pin_subpackage('dal', exact=True) }}
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
-      summary: Devel package for building things linked against DAL shared libraries
+      summary: Devel package for building things linked against Intel® oneDAL shared libraries
+      description: |
+        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+        optimized building blocks covering all stages of data analytics: data acquisition from a data
+        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
       license: Intel Simplified Software License
       license_family: Proprietary
-      license_file: mkl/info/licenses/license.txt
+      license_file:
+         - dal-devel/info/licenses/license.txt
+         - dal-devel/info/licenses/tpp.txt
       license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-      dev_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://github.com/oneapi-src/oneDAL
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -358,7 +386,9 @@ outputs:
       summary: DAAL runtime libraries
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/licenses/license.txt
+      license_file:
+         - dal/info/licenses/license.txt
+         - dal/info/licenses/tpp.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -376,7 +406,9 @@ outputs:
       summary: Headers for building against DAAL libraries
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/licenses/license.txt
+      license_file:
+         - dal-include/info/licenses/license.txt
+         - dal-include/info/licenses/tpp.txt
     test:
       commands:
         - ls -A $PREFIX/include/*  # [unix]
@@ -394,7 +426,9 @@ outputs:
       summary: Static libraries for DAAL
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/licenses/license.txt
+      license_file:
+         - dal-static/info/licenses/license.txt
+         - dal-static/info/licenses/tpp.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
@@ -412,7 +446,9 @@ outputs:
       summary: Devel package for building things linked against DAAL shared libraries
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/licenses/license.txt
+      license_file:
+         - dal-devel/info/licenses/license.txt
+         - dal-devel/info/licenses/tpp.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -363,8 +363,10 @@ outputs:
       license: Intel Simplified Software License
       license_family: Proprietary
       license_file:
-         - dal-devel/info/licenses/license.txt
-         - dal-devel/info/licenses/tpp.txt
+         - dal-devel/licenses/license.txt   # [not win]
+         - dal-devel/licenses/tpp.txt       # [not win]
+         - dal-devel/info/licenses/license.txt   # [win]
+         - dal-devel/info/licenses/tpp.txt       # [win]
       license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
       dev_url: https://github.com/oneapi-src/oneDAL
@@ -447,8 +449,10 @@ outputs:
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
       license_file:
-         - dal-devel/info/licenses/license.txt
-         - dal-devel/info/licenses/tpp.txt
+         - dal-devel/licenses/license.txt   # [not win]
+         - dal-devel/licenses/tpp.txt       # [not win]
+         - dal-devel/info/licenses/license.txt   # [win]
+         - dal-devel/info/licenses/tpp.txt       # [win]
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -193,6 +193,8 @@ outputs:
       run_exports:
         - {{ pin_subpackage('mkl') }}
         - {{ pin_subpackage('blas', exact=True) }}
+        # this was added to prior mkl-devel releases but not in the feedstock. This is used by
+        # various downstreams (mkl_fft, mkl_random) to include the mkl-service wrapper as a dependency.
         - mkl-service >=2.3.0,<3.0a0
     requirements:
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,39 +1,56 @@
-{% set version = "2020.2" %}
-{% set buildnum = "254" %}  # [not osx]
-{% set buildnum = "258" %}  # [osx]
+{% set version = "2021.2.0" %}
+{% set mkl_buildnum = "296" %}  # [not osx]
+{% set mkl_buildnum = "269" %}  # [osx]
 
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '2' %}
+{% set dstbuildnum = '0' %}
 {% set openmp_version = version %}
 # 117 was intel's base build number.  We're up 1 after making the license file not read-only
 # {% set openmp_buildnum = buildnum|int + dstbuildnum|int %}
-{% set openmp_buildnum=buildnum %}
+{% set openmp_buildnum = "610" %}  # [linux]
+{% set openmp_buildnum = "564" %}  # [osx]
+{% set openmp_buildnum = "616" %}  # [win]
+
+{% set daal_version = "2021.2.2" %}
+{% set daal_buildnum = "389" %}  # [linux]
+{% set daal_buildnum = "389" %}  # [osx]
+{% set daal_buildnum = "389" %}  # [win]
 
 package:
   name: intel_repack
   version: {{ version }}
 
 source:
-  - url: https://anaconda.org/intel/mkl/{{ version }}/download/{{ target_platform }}/mkl-{{ version }}-intel_{{ buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/mkl/{{ version }}/download/{{ target_platform }}/mkl-{{ version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl
-  - url: https://anaconda.org/intel/mkl-devel/{{ version }}/download/{{ target_platform }}/mkl-devel-{{ version }}-intel_{{ buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/mkl-devel/{{ version }}/download/{{ target_platform }}/mkl-devel-{{ version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl-devel
-  - url: https://anaconda.org/intel/mkl-include/{{ version }}/download/{{ target_platform }}/mkl-include-{{ version }}-intel_{{ buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/mkl-include/{{ version }}/download/{{ target_platform }}/mkl-include-{{ version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl-include
   - url: https://anaconda.org/intel/intel-openmp/{{ openmp_version }}/download/{{ target_platform }}/intel-openmp-{{ openmp_version }}-intel_{{ openmp_buildnum }}.tar.bz2
     folder: intel-openmp
-  - url: https://anaconda.org/intel/daal/{{ version }}/download/{{ target_platform }}/daal-{{ version }}-intel_{{ buildnum }}.tar.bz2
+  {% if not win32 %}
+  - url: https://anaconda.org/intel/dal/{{ daal_version }}/download/{{ target_platform }}/dal-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
+    folder: dal
+  - url: https://anaconda.org/intel/dal-include/{{ daal_version }}/download/{{ target_platform }}/dal-include-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
+    folder: dal-include
+  - url: https://anaconda.org/intel/dal-static/{{ daal_version }}/download/{{ target_platform }}/dal-static-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
+    folder: dal-static
+  - url: https://anaconda.org/intel/dal-devel/{{ daal_version }}/download/{{ target_platform }}/dal-devel-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
+    folder: dal-devel
+  - url: https://anaconda.org/intel/daal/{{ daal_version }}/download/{{ target_platform }}/daal-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal
-  - url: https://anaconda.org/intel/daal-include/{{ version }}/download/{{ target_platform }}/daal-include-{{ version }}-intel_{{ buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/daal-include/{{ daal_version }}/download/{{ target_platform }}/daal-include-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-include
-  - url: https://anaconda.org/intel/daal-static/{{ version }}/download/{{ target_platform }}/daal-static-{{ version }}-intel_{{ buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/daal-static/{{ daal_version }}/download/{{ target_platform }}/daal-static-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-static
-  - url: https://anaconda.org/intel/daal-devel/{{ version }}/download/{{ target_platform }}/daal-devel-{{ version }}-intel_{{ buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/daal-devel/{{ daal_version }}/download/{{ target_platform }}/daal-devel-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-devel
+  {% endif %}
 
 build:
   # 117 was intel's base build number.  We're up 1 after making the license file not read-only
-  number: {{ buildnum|int + dstbuildnum|int }}
+  number: {{ mkl_buildnum|int + dstbuildnum|int }}
   binary_relocation: false
   detect_binary_files_with_prefix: false
   skip: True                                  # [ppc64le]
@@ -62,6 +79,26 @@ build:
     - /usr/lib/libc++.1.dylib       # [osx]
     # hooray, windows
     - "C:\\Windows\\System32\\WINTRUST.dll"
+    # mostly things for optional runtime targets..
+    - $RPATH/libOpenCL.so.1       # [linux]
+    - $RPATH/libffi.so.6          # [linux]
+    - $RPATH/libimf.so            # [linux]
+    - $RPATH/libintlc.so.5        # [linux]
+    - $RPATH/libiomp5.so          # [linux]
+    - $RPATH/libirng.so           # [linux]
+    - $RPATH/libsvml.so           # [linux]
+    - $RPATH/libze_loader.so.1    # [linux]
+    - $RPATH/libtbb.so.12         # [linux]
+    - '**/librt.so.1'             # [linux]
+    - '**/libelf.so.1'            # [linux]
+    - $RPATH/libtbb.12.dylib      # [osx]
+    - $RPATH/ze_loader.dll        # [win]
+    - $RPATH/impi.dll             # [win]
+    - $RPATH/msmpi.dll            # [win]
+    - $RPATH/mpich2mpi.dll        # [win]
+    - $RPATH/pgc.dll              # [win]
+    - $RPATH/pgf90.dll            # [win]
+    - $RPATH/pgmath.dll           # [win]
 
 outputs:
   - name: mkl
@@ -69,15 +106,20 @@ outputs:
     script: repack.bat  # [win]
     requirements:
       host:
-        - intel-openmp
+        - intel-openmp {{ version.split('.')[0] }}.*
+        # - tbb {{ version.split('.')[0] }}.*
       run:
-        - intel-openmp
+        - intel-openmp {{ version.split('.')[0] }}.*
+        # - tbb {{ version.split('.')[0] }}.*
+      run_constrained:      # [linux or osx]
+        # intel-openmp 2021.1.1 and newer is built with a newer GLIBC
+        - __glibc >=2.17    # [linux]
+        - __osx >=10.13     # [osx]
     about:
       home: https://software.intel.com/en-us/mkl
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/LICENSE.txt  # [win]
-      license_file: mkl/info/licenses/license.txt  # [unix]
+      license_file: mkl/info/licenses/license.txt
       summary: Math library for Intel and compatible processors
       description: |
         Intel Math Kernel Library is a BLAS implementation tuned for high performance on Intel CPUs.
@@ -94,8 +136,7 @@ outputs:
       home: https://software.intel.com/en-us/mkl
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/LICENSE.txt  # [win]
-      license_file: mkl/info/licenses/license.txt  # [unix]
+      license_file: mkl/info/licenses/license.txt
       summary: MKL headers for developing software that uses MKL
       description: |
         Intel Math Kernel Library is a BLAS implementation tuned for high performance on Intel CPUs.
@@ -110,12 +151,15 @@ outputs:
     script: repack.bat  # [win]
     number: {{ openmp_buildnum }}
     version: {{ openmp_version }}
+    requirements:           # [linux]
+      run_constrained:      # [linux]
+        # intel-openmp 2021.1.1 and newer is built with a newer GLIBC
+        - __glibc >=2.17    # [linux]
     about:
       home: https://software.intel.com/en-us/node/522690
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/LICENSE.txt  # [win]
-      license_file: mkl/info/licenses/license.txt  # [unix]
+      license_file: mkl/info/licenses/license.txt
       summary: Math library for Intel and compatible processors
       description: |
         Intel openmp runtime implementation
@@ -143,13 +187,13 @@ outputs:
     script: install-devel.sh   # [unix]
     script: install-devel.bat  # [win]
     build:
-      # we had to fix site.cfg in 2019.1.  We're off by one.
-      number: {{ buildnum|int + dstbuildnum|int + 1 }}
+      number: {{ mkl_buildnum|int + dstbuildnum|int }}
       # when stuff is built with MKL, ensure that constraint makes mkl runtime libs as new or
       #     newer than build version
       run_exports:
         - {{ pin_subpackage('mkl') }}
         - {{ pin_subpackage('blas', exact=True) }}
+        - mkl-service >=2.3.0,<3.0a0
     requirements:
       run:
         - {{ pin_subpackage('mkl', exact=True) }}
@@ -160,20 +204,23 @@ outputs:
       summary: Metapackage of MKL headers and libraries for developing software that uses MKL
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/LICENSE.txt  # [win]
-      license_file: mkl/info/licenses/license.txt  # [unix]
+      license_file: mkl/info/licenses/license.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
         - ls -A $PREFIX/include/*  # [unix]
 
-  - name: daal
+  - name: dal
+    version: {{ daal_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      number: {{ buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + dstbuildnum|int }}
       binary_relocation: false
       detect_binary_files_with_prefix: false
+      skip: True                                  # [win32]
+      ignore_run_exports:   # [linux or win]
+        - tbb               # [linux or win]
       missing_dso_whitelist:
         # just ignore tbb on mac.  We could add it as a dep when we have it.
         - libtbb.dylib                   # [osx]
@@ -190,8 +237,15 @@ outputs:
         - /lib*/libc.so.6
         - /lib*/libm.so.6
         - lib/libgcc_s.so.1
-        - "$RPATH/libtbb.2.so"
-        - "$RPATH/libtbbmalloc.so.1"
+        - "$RPATH/libtbb.so.12"
+        - "$RPATH/libtbbmalloc.so.2"
+        # these are contained in Intel's optional common_cmplr_lib_rt.
+        - "$RPATH/libsvml.so"
+        - "$RPATH/libirng.so"
+        - "$RPATH/libimf.so"
+        - "$RPATH/libintlc.so.5"
+        # # this comes from Intel's optional dpcpp_cpp_rt
+        - "$RPATH/libsycl.so.5"
         # these two really shouldn't be here.  See mkl_repack_and_patchelf.sh
         - libiomp5.so
         - libcoi_device.so.0
@@ -200,80 +254,170 @@ outputs:
         - /usr/lib/libc++.1.dylib       # [osx]
         # hooray, windows
         - "C:\\Windows\\System32\\WINTRUST.dll"
+        # optional dpcpp runtime that we do not yet provide.
+        - $RPATH/sycl.dll               # [win]
     requirements:
       host:
-        - tbb {{ version.split('.')[0] }}.*
+        - tbb {{ daal_version.split('.')[0] }}.*
       run:
-        - tbb {{ version.split('.')[0] }}.*
+        - tbb {{ daal_version.split('.')[0] }}.*
+    about:
+      home: https://software.intel.com/content/www/us/en/develop/tools.html
+      summary: DAL runtime libraries
+      license: Intel Simplified Software License
+      license_family: Proprietary
+      license_file: mkl/info/licenses/license.txt
+      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://software.intel.com/content/www/us/en/develop/tools.html
+    test:
+      commands:
+        - ls -A $PREFIX/lib/*  # [unix]
+
+  - name: dal-include
+    version: {{ daal_version }}
+    script: repack.sh   # [unix]
+    script: repack.bat  # [win]
+    build:
+      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      skip: True                                  # [win32]
+    about:
+      home: https://software.intel.com/content/www/us/en/develop/tools.html
+      summary: Headers for building against DAL libraries
+      license: Intel Simplified Software License
+      license_family: Proprietary
+      license_file: mkl/info/licenses/license.txt
+      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://software.intel.com/content/www/us/en/develop/tools.html
+    test:
+      commands:
+        - ls -A $PREFIX/include/*  # [unix]
+
+  - name: dal-static
+    version: {{ daal_version }}
+    script: repack.sh   # [unix]
+    script: repack.bat  # [win]
+    build:
+      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      skip: True                                  # [win32]
+    requirements:
+      run:
+        - {{ pin_subpackage('dal-include', exact=True) }}
+        - tbb {{ daal_version.split('.')[0] }}.*
+    about:
+      home: https://software.intel.com/content/www/us/en/develop/tools.html
+      summary: Static libraries for DAL
+      license: Intel Simplified Software License
+      license_family: Proprietary
+      license_file: mkl/info/licenses/license.txt
+      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://software.intel.com/content/www/us/en/develop/tools.html
+    test:
+      commands:
+        - ls -A $PREFIX/lib/*  # [unix]
+
+  - name: dal-devel
+    version: {{ daal_version }}
+    script: repack.sh   # [unix]
+    script: repack.bat  # [win]
+    build:
+      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      skip: True                                  # [win32]
+      run_exports:
+        - {{ pin_subpackage('dal') }}
+    requirements:
+      run:
+        - {{ pin_subpackage('dal-include', exact=True) }}
+        - {{ pin_subpackage('dal', exact=True) }}
+    about:
+      home: https://software.intel.com/content/www/us/en/develop/tools.html
+      summary: Devel package for building things linked against DAL shared libraries
+      license: Intel Simplified Software License
+      license_family: Proprietary
+      license_file: mkl/info/licenses/license.txt
+      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://software.intel.com/content/www/us/en/develop/tools.html
+    test:
+      commands:
+        - ls -A $PREFIX/lib/*  # [unix]
+        - ls -A $PREFIX/include/*  # [unix]
+
+  - name: daal
+    version: {{ daal_version }}
+    build:
+      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      skip: True                                  # [win32]
+    requirements:
+      run:
+        - {{ pin_subpackage('dal', max_pin='x') }}
     about:
       home: https://software.intel.com/en-us/daal
       summary: DAAL runtime libraries
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/LICENSE.txt  # [win]
-      license_file: mkl/info/licenses/license.txt  # [unix]
+      license_file: mkl/info/licenses/license.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
 
   - name: daal-include
-    script: repack.sh   # [unix]
-    script: repack.bat  # [win]
+    version: {{ daal_version }}
     build:
-      number: {{ buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      skip: True                                  # [win32]
+    requirements:
+      run:
+        - {{ pin_subpackage('dal-include', max_pin='x') }}
     about:
       home: https://software.intel.com/en-us/daal
       summary: Headers for building against DAAL libraries
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/LICENSE.txt  # [win]
-      license_file: mkl/info/licenses/license.txt  # [unix]
+      license_file: mkl/info/licenses/license.txt
     test:
       commands:
         - ls -A $PREFIX/include/*  # [unix]
 
   - name: daal-static
-    script: repack.sh   # [unix]
-    script: repack.bat  # [win]
+    version: {{ daal_version }}
     build:
-      number: {{ buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      skip: True                                  # [win32]
     requirements:
       run:
-        - {{ pin_subpackage('daal-include', exact=True) }}
-        - tbb {{ version.split('.')[0] }}.*
+        - {{ pin_subpackage('dal-static', max_pin='x') }}
     about:
       home: https://software.intel.com/en-us/daal
       summary: Static libraries for DAAL
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/LICENSE.txt  # [win]
-      license_file: mkl/info/licenses/license.txt  # [unix]
+      license_file: mkl/info/licenses/license.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
 
   - name: daal-devel
-    script: repack.sh   # [unix]
-    script: repack.bat  # [win]
+    version: {{ daal_version }}
     build:
-      number: {{ buildnum|int + dstbuildnum|int }}
-      run_exports:
-        - {{ pin_subpackage('daal') }}
+      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      skip: True                                  # [win32]
     requirements:
       run:
-        - {{ pin_subpackage('daal-include', exact=True) }}
-        - {{ pin_subpackage('daal', exact=True) }}
+        - {{ pin_subpackage('dal-devel', max_pin='x') }}
     about:
       home: https://software.intel.com/en-us/daal
       summary: Devel package for building things linked against DAAL shared libraries
       license: LicenseRef-ProprietaryIntel
       license_family: Proprietary
-      license_file: mkl/info/LICENSE.txt  # [win]
-      license_file: mkl/info/licenses/license.txt  # [unix]
+      license_file: mkl/info/licenses/license.txt
     test:
       commands:
         - ls -A $PREFIX/lib/*  # [unix]
         - ls -A $PREFIX/include/*  # [unix]
+
 # please the linter
 about:
   home: https://github.com/conda-forge/intel-repack-feedstock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -107,10 +107,8 @@ outputs:
     requirements:
       host:
         - intel-openmp {{ version.split('.')[0] }}.*
-        # - tbb {{ version.split('.')[0] }}.*
       run:
         - intel-openmp {{ version.split('.')[0] }}.*
-        # - tbb {{ version.split('.')[0] }}.*
       run_constrained:      # [linux or osx]
         # intel-openmp 2021.1.1 and newer is built with a newer GLIBC
         - __glibc >=2.17    # [linux]

--- a/recipe/repack.bat
+++ b/recipe/repack.bat
@@ -1,5 +1,11 @@
 set "src=%SRC_DIR%\%PKG_NAME%"
-COPY %src%\info\LICENSE.txt %SRC_DIR%
+
+if exist %src%\info\LICENSE.txt (
+    COPY %src%\info\LICENSE.txt %SRC_DIR%
+) else (
+    COPY %SRC_DIR%\mkl\info\licenses\license.txt %SRC_DIR%
+)
+
 robocopy /E "%src%" "%PREFIX%"
 if %ERRORLEVEL% GEQ 8 exit 1
 

--- a/recipe/repack.bat
+++ b/recipe/repack.bat
@@ -1,10 +1,11 @@
 set "src=%SRC_DIR%\%PKG_NAME%"
 
-if exist %src%\info\LICENSE.txt (
-    COPY %src%\info\LICENSE.txt %SRC_DIR%
-) else (
-    COPY %SRC_DIR%\mkl\info\licenses\license.txt %SRC_DIR%
-)
+@REM @REM The license files are no longer manually packed but are included via the meta.yaml
+@REM if exist %src%\info\LICENSE.txt (
+@REM     COPY %src%\info\LICENSE.txt %SRC_DIR%
+@REM ) else (
+@REM     COPY %SRC_DIR%\mkl\info\licenses\license.txt %SRC_DIR%
+@REM )
 
 robocopy /E "%src%" "%PREFIX%"
 if %ERRORLEVEL% GEQ 8 exit 1

--- a/recipe/repack.sh
+++ b/recipe/repack.sh
@@ -5,12 +5,14 @@ set -ex
 #    That's what this $PKG_NAME is doing - picking the right subfolder to rsync
 
 src="$SRC_DIR/$PKG_NAME"
-# not all packages have the license file.  Copy it from mkl, where we know it exists
-cp -f "$SRC_DIR/mkl/info/licenses/license.txt" "$SRC_DIR"
-cp -rv "$src"/* "$PREFIX/"
 
-# ro by default.  Makes installations not cleanly removable.
-chmod 664 "$SRC_DIR/license.txt"
+# # The license files are no longer manually packed but are included via the meta.yaml
+# # not all packages have the license file.  Copy it from mkl, where we know it exists
+# cp -f "$SRC_DIR/mkl/info/licenses/license.txt" "$SRC_DIR"
+# # ro by default.  Makes installations not cleanly removable.
+# chmod 664 "$SRC_DIR/license.txt"
+
+cp -rv "$src"/* "$PREFIX/"
 
 # replace old info folder with our new regenerated one
 rm -rf "$PREFIX/info"


### PR DESCRIPTION
- MKL 2021 run constrains on GLIBC and OSX.
- Do not re-package `dal` on windows `win-32` as it is not provided upstream.
- License standardization between unix & windows as they are located in the same place now.
- `daal` -> `dal` updates.