### PR TITLE
Main 2022.1.0

### DIFF
--- a/recipe/install-devel.bat
+++ b/recipe/install-devel.bat
@@ -1,5 +1,5 @@
 set "src=%SRC_DIR%\%PKG_NAME%"
-COPY "%src%\info\LICENSE.txt" "%SRC_DIR%"
+COPY "%src%\info\licenses\LICENSE.txt" "%SRC_DIR%"
 
 COPY %RECIPE_DIR%\site.cfg %PREFIX%\site.cfg
 unix2dos %PREFIX%\site.cfg

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -126,19 +126,25 @@ outputs:
     build:
       number: {{ openmp_buildnum|int + build_number_bump|int }}
       missing_dso_whitelist:
-        # - "$RPATH/libintlc.so.5"
-    requirements:           # [linux]
+        # OS specific:
+        - "$RPATH/libelf.so.1"            # [linux] - OS file.
+        # Optional `intel-opencl-rt`:
+        - "$RPATH/libOpenCL.so.1"         # [linux] - optional `intel-opencl-rt`
+        # Optional oneAPI Level Zero Loader:
+        - "$RPATH/libze_loader.so.1"      # [linux] - optional oneAPI Level Zero loader.
+        # Others...
+
+    requirements:
       build:
         - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
-      run_constrained:      # [linux]
-        - __glibc >=2.17    # [linux] - intel-openmp 2021.1.1 and newer is built with a newer GLIBC
+      run_constrained:                    # [linux]
+        - __glibc >=2.17                  # [linux] - intel-openmp 2021.1.1 and newer is built with a newer GLIBC
       host:
-        - intel-cmplr-lib-rt
         - zlib
+        - libffi
       run:
-        - intel-cmplr-lib-rt
-        - intel-opencl-rt
         - zlib
+        - libffi
     about:
       home: https://software.intel.com/en-us/node/522690
       license: LicenseRef-ProprietaryIntel
@@ -204,29 +210,7 @@ outputs:
       number: {{ dal_buildnum|int + build_number_bump|int }}
       binary_relocation: false
       detect_binary_files_with_prefix: false
-      ignore_run_exports:   # [linux or win]
-        - tbb               # [linux or win]
       missing_dso_whitelist:
-        - libtbb.dylib                    # [osx]  just ignore tbb on mac.  We could add
-        # it as a dep when we have it.
-        - "$RPATH/libtbb.dylib"           # [osx]
-        # this one should be here, probably needs fixup of RUNPATH/RPATH
-        - libiomp5.dylib                  # [osx]
-        - "$RPATH/libiomp5.dylib"         # [osx]
-        - "$RPATH/libc++.1.dylib"         # [osx]
-        # normal linux stuff that would go away if we had libgcc-ng in the run deps
-        - "$RPATH/ld-linux-x86-64.so.2"   # [linux]
-        - "$RPATH/ld-linux.so.2"          # [linux]
-        - "$RPATH/libc.so.6"              # [linux]
-        - "$RPATH/libdl.so.2"             # [linux]
-        - "$RPATH/libgcc_s.so.1"          # [linux]
-        - "$RPATH/libm.so.6"              # [linux]
-        - "$RPATH/libpthread.so.0"        # [linux]
-        - "$RPATH/libstdc++.so.6"         # [linux]
-        - "$RPATH/libtbb.so.12"           # [linux]
-        - "$RPATH/libtbbmalloc.so.2"      # [linux]
-        - "$RPATHibgcc_s.so.1"            # [linux]
-        - "$RPATHlibz.so.1"               # [linux]
         # these are contained in Intel's optional common_cmplr_lib_rt (now intel-cmplr-lib-rt).
         - "$RPATH/libsvml.so"
         - "$RPATH/libirng.so"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,7 +87,7 @@ outputs:
         - "$RPATH/libtbbmalloc.so.2"
     requirements:
       build:
-        - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
       host:
         - intel-openmp {{ openmp_version.split('.')[0] }}.*
       run:
@@ -152,7 +152,7 @@ outputs:
 
     requirements:
       build:
-        - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
       run_constrained:                    # [linux]
         - __glibc >=2.17                  # [linux] - intel-openmp 2021.1.1 and newer is built with a newer GLIBC
       host:
@@ -246,7 +246,7 @@ outputs:
         - "$RPATH/svml_dispmd.dll"        # [win]
     requirements:
       build:
-        - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
       host:
         - tbb {{ dal_version.split('.')[0] }}.*
       run:
@@ -313,7 +313,7 @@ outputs:
         - $RPATH/svml_dispmd.dll      # [win]
     requirements:
       build:
-        - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
       run:
         - {{ pin_subpackage('dal-include', exact=True) }}
         - tbb {{ dal_version.split('.')[0] }}.*
@@ -347,7 +347,7 @@ outputs:
         - {{ pin_subpackage('dal') }}
     requirements:
       build:
-        - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
       run:
         - {{ pin_subpackage('dal-include', exact=True) }}
         - {{ pin_subpackage('dal', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,62 +1,82 @@
-{% set version = "2022.0.1" %}  # [linux]
-{% set version = "2022.0.0" %}  # [win or osx]
-{% set mkl_buildnum = "117" %}  # [linux]
-{% set mkl_buildnum = "105" %}  # [osx]
-{% set mkl_buildnum = "115" %}  # [win]
 
-# use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '0' %}
-{% set openmp_version = version %}
-# 117 was intel's base build number.  We're up 1 after making the license file not read-only
-# {% set openmp_buildnum = buildnum|int + dstbuildnum|int %}
-{% set openmp_buildnum = "3633" %}  # [linux]
-{% set openmp_buildnum = "3615" %}  # [osx]
-{% set openmp_buildnum = "3663" %}  # [win]
 
-{% set daal_version = "2021.5.1" %}  # [linux]
-{% set daal_version = "2021.5.0" %}  # [win or osx]
-{% set daal_buildnum = "803" %}  # [linux]
-{% set daal_buildnum = "782" %}  # [osx]
-{% set daal_buildnum = "796" %}  # [win]
+# Linux
+{% set mkl_version = "2022.1.0" %}      # [linux]
+{% set mkl_buildnum = "223" %}          # [linux]
+{% set openmp_version = mkl_version %}  # [linux]
+{% set openmp_buildnum = "3633" %}      # [linux]
+{% set daal_version = "2021.6.0" %}     # [linux]
+{% set daal_buildnum = "915" %}         # [linux]
+
+# OSX
+{% set mkl_version = "2022.1.0" %}      # [osx]
+{% set mkl_buildnum = "208" %}          # [osx]
+{% set openmp_version = mkl_version %}  # [osx]
+{% set openmp_buildnum = "3615" %}      # [osx]
+{% set daal_version = "2021.6.0" %}     # [osx]
+{% set daal_buildnum = "928" %}         # [osx]
+
+# Windows
+{% set mkl_version = "2022.1.0" %}      # [win]
+{% set mkl_buildnum = "192" %}          # [win]
+{% set openmp_version = mkl_version %}  # [win]
+{% set openmp_buildnum = "3663" %}      # [win]
+{% set daal_version = "2021.6.0" %}     # [win]
+{% set daal_buildnum = "874" %}         # [win]
+
+
+# We will use the <X>_buildnumber for the package buildnumber; however, when it's necessary to bump
+# the build number, this variable is used to increment it.
+{% set build_number_bump = '0' %}
+
 
 package:
   name: intel_repack
-  version: {{ version }}
+  version: {{ mkl_version }}
 
 source:
-  - url: https://anaconda.org/intel/mkl/{{ version }}/download/{{ target_platform }}/mkl-{{ version }}-intel_{{ mkl_buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/mkl/{{ mkl_version }}/download/{{ target_platform }}/mkl-{{ mkl_version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl
-  - url: https://anaconda.org/intel/mkl-devel/{{ version }}/download/{{ target_platform }}/mkl-devel-{{ version }}-intel_{{ mkl_buildnum }}.tar.bz2
+    sha256: 1
+  - url: https://anaconda.org/intel/mkl-devel/{{ mkl_version }}/download/{{ target_platform }}/mkl-devel-{{ mkl_version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl-devel
-  - url: https://anaconda.org/intel/mkl-include/{{ version }}/download/{{ target_platform }}/mkl-include-{{ version }}-intel_{{ mkl_buildnum }}.tar.bz2
+    sha256: 1
+  - url: https://anaconda.org/intel/mkl-include/{{ mkl_version }}/download/{{ target_platform }}/mkl-include-{{ mkl_version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl-include
+    sha256: 1
   - url: https://anaconda.org/intel/intel-openmp/{{ openmp_version }}/download/{{ target_platform }}/intel-openmp-{{ openmp_version }}-intel_{{ openmp_buildnum }}.tar.bz2
     folder: intel-openmp
-  {% if not win32 %}
+    sha256: 1
   - url: https://anaconda.org/intel/dal/{{ daal_version }}/download/{{ target_platform }}/dal-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: dal
+    sha256: 1
   - url: https://anaconda.org/intel/dal-include/{{ daal_version }}/download/{{ target_platform }}/dal-include-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: dal-include
+    sha256: 1
   - url: https://anaconda.org/intel/dal-static/{{ daal_version }}/download/{{ target_platform }}/dal-static-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: dal-static
+    sha256: 1
   - url: https://anaconda.org/intel/dal-devel/{{ daal_version }}/download/{{ target_platform }}/dal-devel-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: dal-devel
+    sha256: 1
   - url: https://anaconda.org/intel/daal/{{ daal_version }}/download/{{ target_platform }}/daal-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal
+    sha256: 1
   - url: https://anaconda.org/intel/daal-include/{{ daal_version }}/download/{{ target_platform }}/daal-include-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-include
+    sha256: 1
   - url: https://anaconda.org/intel/daal-static/{{ daal_version }}/download/{{ target_platform }}/daal-static-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-static
+    sha256: 1
   - url: https://anaconda.org/intel/daal-devel/{{ daal_version }}/download/{{ target_platform }}/daal-devel-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-devel
-  {% endif %}
+    sha256: 1
 
 build:
-  # 117 was intel's base build number.  We're up 1 after making the license file not read-only
-  number: {{ mkl_buildnum|int + dstbuildnum|int }}
+  number: {{ mkl_buildnum|int + build_number_bump|int }}
   binary_relocation: false
   detect_binary_files_with_prefix: false
-  skip: True                                  # [not (x86 and (linux or win or osx))]
+  skip: True             # [win32 or (not x86) or (not (linux or win or osx))]
   runpath_whitelist:
     - $ORIGIN
   missing_dso_whitelist:
@@ -116,9 +136,9 @@ outputs:
     script: repack.bat  # [win]
     requirements:
       host:
-        - intel-openmp {{ version.split('.')[0] }}.*
+        - intel-openmp {{ mkl_version.split('.')[0] }}.*
       run:
-        - intel-openmp {{ version.split('.')[0] }}.*
+        - intel-openmp {{ mkl_version.split('.')[0] }}.*
       run_constrained:      # [linux or osx]
         # intel-openmp 2021.1.1 and newer is built with a newer GLIBC
         - __glibc >=2.17    # [linux]
@@ -195,7 +215,7 @@ outputs:
     script: install-devel.sh   # [unix]
     script: install-devel.bat  # [win]
     build:
-      number: {{ mkl_buildnum|int + dstbuildnum|int }}
+      number: {{ mkl_buildnum|int + build_number_bump|int }}
       # when stuff is built with MKL, ensure that constraint makes mkl runtime libs as new or
       #     newer than build version
       run_exports:
@@ -225,7 +245,7 @@ outputs:
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + build_number_bump|int }}
       binary_relocation: false
       detect_binary_files_with_prefix: false
       skip: True                                  # [win32]
@@ -300,7 +320,7 @@ outputs:
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + build_number_bump|int }}
       skip: True                                  # [win32]
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
@@ -327,7 +347,7 @@ outputs:
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + build_number_bump|int }}
       skip: True                                  # [win32]
       missing_dso_whitelist:
         - $RPATH/sycld.dll            # [win]
@@ -366,7 +386,7 @@ outputs:
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + build_number_bump|int }}
       skip: True                                  # [win32]
       run_exports:
         - {{ pin_subpackage('dal') }}
@@ -404,7 +424,7 @@ outputs:
   - name: daal
     version: {{ daal_version }}
     build:
-      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + build_number_bump|int }}
       skip: True                                  # [win32]
     requirements:
       run:
@@ -427,7 +447,7 @@ outputs:
   - name: daal-include
     version: {{ daal_version }}
     build:
-      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + build_number_bump|int }}
       skip: True                                  # [win32]
     requirements:
       run:
@@ -450,7 +470,7 @@ outputs:
   - name: daal-static
     version: {{ daal_version }}
     build:
-      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + build_number_bump|int }}
       skip: True                                  # [win32]
     requirements:
       run:
@@ -473,7 +493,7 @@ outputs:
   - name: daal-devel
     version: {{ daal_version }}
     build:
-      number: {{ daal_buildnum|int + dstbuildnum|int }}
+      number: {{ daal_buildnum|int + build_number_bump|int }}
       skip: True                                  # [win32]
     requirements:
       run:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -153,6 +153,7 @@ outputs:
         - "$RPATH/libsvml.so"             # [linux] - intel-cmplr-lib-rt.
         # Optional `intel-opencl-rt`:
         - "$RPATH/libOpenCL.so.1"         # [linux] - optional `intel-opencl-rt`.
+        - "$RPATH/OpenCL.dll"             # [win]   - optional `intel-opencl-rt`.
         # Optional oneAPI Level Zero Loader:
         - "$RPATH/libze_loader.so.1"      # [linux] - optional oneAPI Level Zero loader.
         - "$RPATH/ze_loader.dll"          # [win]   - optional oneAPI Level Zero loader.
@@ -243,6 +244,9 @@ outputs:
         - "$RPATH/libirng.so"             # [linux]
         - "$RPATH/libsvml.so"             # [linux]
         - "$RPATH/libmmd.dll"             # [win]
+        # Optional `intel-opencl-rt`:
+        - "$RPATH/libOpenCL.so.1"         # [linux]
+        - "$RPATH/OpenCL.dll"             # [win]
         # # this comes from Intel's optional dpcpp_cpp_rt
         - "$RPATH/libsycl.so.5"           # [linux]
         # these two really shouldn't be here.  See mkl_repack_and_patchelf.sh

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@
 {% set openmp_version = mkl_version %}  # [linux]
 {% set openmp_buildnum = "3768" %}      # [linux]
 {% set daal_version = "2021.6.0" %}     # [linux]
-{% set daal_buildnum = "915" %}         # [linux]
+{% set daal_buildnum = "928" %}         # [linux]
 
 # OSX
 {% set mkl_version = "2022.1.0" %}      # [osx]
@@ -14,7 +14,7 @@
 {% set openmp_version = mkl_version %}  # [osx]
 {% set openmp_buildnum = "3718" %}      # [osx]
 {% set daal_version = "2021.6.0" %}     # [osx]
-{% set daal_buildnum = "928" %}         # [osx]
+{% set daal_buildnum = "915" %}         # [osx]
 
 # Windows
 {% set mkl_version = "2022.1.0" %}      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,20 @@
 {% set daal_version = "2021.5.3" %}     # [linux]
 {% set daal_buildnum = "832" %}         # [linux]
 
+{% set mkl_hash = "31c225ce08d3dc129f0881e5d36a1ef0ba8dc9fdc0e168397c2ac144d5f0bf54" %}           # [linux]
+{% set mkl_devel_hash = "4e014e6ac31e8961f09c937b66f53d2c0d75f074f39abfa9f378f4659ed2ecbb" %}     # [linux]
+{% set mkl_include_hash = "704e658a9b25a200f8035f3d0a8f2e094736496a2169f87609f1cfed2e2eb0a9" %}   # [linux]
+{% set intel_openmp_hash = "498dc37ce1bd513f591b633565151c4de8f11a12914814f2bf85afebbd35ee23" %}  # [linux]
+{% set dal_hash = "e456f92ed30d77c00583a1b0fe6fc41358415c60a62709ece57503f7a9215fc1" %}           # [linux]
+{% set dal_include_hash = "e3bba390db7e36b4cfcf781a503b4cff79d49bcdc8b45f059f4b1a0459a7e3ef" %}   # [linux]
+{% set dal_static_hash = "df1cff3ef35951b49b874ee6ccdff2a266e552c8114ac7abe853d4b41856bff9" %}    # [linux]
+{% set dal_devel_hash = "75dbf1b002cc8d40f45d8172d58e3a2143c61d340bb81ae86588a2869a7f71e3" %}     # [linux]
+{% set daal_hash = "092be0168b46861ed1eda1467ce1d13f9c6eaa7ee936a232db6638a37b0c3678" %}          # [linux]
+{% set daal_include_hash = "83cfc95049a91b32895644fff532512359e33d9a26e079c4f74c2c72556ffbd8" %}  # [linux]
+{% set daal_static_hash = "eaf8a0aa2ef5fb73bc96dbb64c3fbde502a9c4fd2c0044331009cf92916b995c" %}   # [linux]
+{% set daal_devel_hash = "a982199ffd3d096712a6650fe02a4df4068e0093bf9f0106d9348f9cddce1fa4" %}    # [linux]
+
+
 # OSX
 {% set mkl_version = "2022.1.0" %}      # [osx]
 {% set mkl_buildnum = "208" %}          # [osx]
@@ -19,6 +33,19 @@
 {% set dal_buildnum = "928" %}          # [osx]
 {% set daal_version = "2021.5.0" %}     # [osx]
 {% set daal_buildnum = "782" %}         # [osx]
+
+{% set mkl_hash = "98ceaefa60718bbcda84211f56396ed2e7e88484223708643d6ef6aa6b58f7d5" %}           # [osx]
+{% set mkl_devel_hash = "bcf59ca046690f5727b7263588408d613e448b44fd7afa65e22755788f68c6af" %}     # [osx]
+{% set mkl_include_hash = "569ea516148726b2698f17982aba2d9ec1bfb321f0180be938eddbc696addbc5" %}   # [osx]
+{% set intel_openmp_hash = "ae42df1b6129bbd7708feb6dbd5be6c72da3947b38407a5aca468765cdfef271" %}  # [osx]
+{% set dal_hash = "f651e775de1508aa81fb01b8bd5c0ca7ffbdeadb7970411e31968e4bd759340d" %}           # [osx]
+{% set dal_include_hash = "d2526ce9ba92eb9f2062df091c58c0b55069bcfe0e729a3892df8f601e194ba2" %}   # [osx]
+{% set dal_static_hash = "325924c0c38a49985cfa21d2a95369c90037ba9c3563b15cfc7f935dfde1d130" %}    # [osx]
+{% set dal_devel_hash = "6910088e7135b316b5e7d7de35c4093f4598b93ff726f8e11d6bf5ddaba9dd2c" %}     # [osx]
+{% set daal_hash = "8d36f8d11e1af1bcc5affefc6e61c1bc60a1b1070ee780e968a91327e352b14a" %}          # [osx]
+{% set daal_include_hash = "cd32960bf52d7dbaa831a4df8761352e61cf022ced409daf79be5672871a5787" %}  # [osx]
+{% set daal_static_hash = "6c73100f2eb68d1feb8ea0edd188ee2d0a0cf29f5be01f6b180e895a1d5b5b18" %}   # [osx]
+{% set daal_devel_hash = "fce48865aad6f67a6ee35efb17aaadc0da6fdd6e0e578420e60e7480c55bf3e0" %}    # [osx]
 
 # Windows
 {% set mkl_version = "2022.1.0" %}      # [win]
@@ -30,8 +57,21 @@
 {% set daal_version = "2021.5.4" %}     # [win]
 {% set daal_buildnum = "854" %}         # [win]
 
+{% set mkl_hash = "090e0a6121ecc09c3036b96a487cc975386b9c934fe1e3ece5457db7f39baae8" %}           # [win]
+{% set mkl_devel_hash = "d5080027cb5a1450cb9ed6aa633be34d6c97a9a8cbd5ca90aa226b0e13b71166" %}     # [win]
+{% set mkl_include_hash = "b6452e8c4891fcfab452bc23c6adc9c61ab6635fa494bb2b29725473c1013abc" %}   # [win]
+{% set intel_openmp_hash = "5ad78e140b656632361f8b49456f1768727fe7a17ca1dde3d6a2bd9ce3433e8a" %}  # [win]
+{% set dal_hash = "51a388d5cb9212a87e0ab5f02a978105cc28f0dfe0366610d723f9dfab8f9511" %}           # [win]
+{% set dal_include_hash = "15867d2f83d26e21468c178b8760de12534b267eae8a46f439d8427cd7b469ef" %}   # [win]
+{% set dal_static_hash = "e7045f200522fcd5fd471072aeed1ca4df9ad06617feadb9040e5b2c55bfbced" %}    # [win]
+{% set dal_devel_hash = "7da9f5964534256e44eb1e8d1bdcad9950763d524b4cf66aa85847f422700714" %}     # [win]
+{% set daal_hash = "d3db345f3acd4d951e218301f480001b4994a639cb552d326215c8f1594d5c5a" %}          # [win]
+{% set daal_include_hash = "ea3ad17eca1ecea588e641706c40fa6895ca3e0f3d10cd9c92e8a6f6ff9865aa" %}  # [win]
+{% set daal_static_hash = "d3db345f3acd4d951e218301f480001b4994a639cb552d326215c8f1594d5c5a" %}   # [win]
+{% set daal_devel_hash = "8799109a566c4a3d2f5e3800b5365e639da7f5d6032052020ceed1e801e228f5" %}    # [win]
 
-# We will use the <X>_buildnumber for the package buildnumber; however, when it's necessary to bump
+
+# We will use the <X>_buildnumber for the package buildnumber (where x is mkl, dal, etc); however, when it's necessary to bump
 # the build number, this variable is used to increment it.
 {% set build_number_bump = '0' %}
 
@@ -41,31 +81,42 @@ package:
   version: {{ mkl_version }}
 
 source:
-  # Conscider adding sha256 fields here.
   - url: https://anaconda.org/intel/mkl/{{ mkl_version }}/download/{{ target_platform }}/mkl-{{ mkl_version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl
+    sha256: {{ mkl_hash }}
   - url: https://anaconda.org/intel/mkl-devel/{{ mkl_version }}/download/{{ target_platform }}/mkl-devel-{{ mkl_version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl-devel
+    sha256: {{ mkl_devel_hash }}
   - url: https://anaconda.org/intel/mkl-include/{{ mkl_version }}/download/{{ target_platform }}/mkl-include-{{ mkl_version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl-include
+    sha256: {{ mkl_include_hash }}
   - url: https://anaconda.org/intel/intel-openmp/{{ openmp_version }}/download/{{ target_platform }}/intel-openmp-{{ openmp_version }}-intel_{{ openmp_buildnum }}.tar.bz2
     folder: intel-openmp
+    sha256: {{ intel_openmp_hash }}
   - url: https://anaconda.org/intel/dal/{{ dal_version }}/download/{{ target_platform }}/dal-{{ dal_version }}-intel_{{ dal_buildnum }}.tar.bz2
     folder: dal
+    sha256: {{ dal_hash }}
   - url: https://anaconda.org/intel/dal-include/{{ dal_version }}/download/{{ target_platform }}/dal-include-{{ dal_version }}-intel_{{ dal_buildnum }}.tar.bz2
     folder: dal-include
+    sha256: {{ dal_include_hash }}
   - url: https://anaconda.org/intel/dal-static/{{ dal_version }}/download/{{ target_platform }}/dal-static-{{ dal_version }}-intel_{{ dal_buildnum }}.tar.bz2
     folder: dal-static
+    sha256: {{ dal_static_hash }}
   - url: https://anaconda.org/intel/dal-devel/{{ dal_version }}/download/{{ target_platform }}/dal-devel-{{ dal_version }}-intel_{{ dal_buildnum }}.tar.bz2
     folder: dal-devel
+    sha256: {{ dal_devel_hash }}
   - url: https://anaconda.org/intel/daal/{{ daal_version }}/download/{{ target_platform }}/daal-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal
+    sha256: {{ daal_hash }}
   - url: https://anaconda.org/intel/daal-include/{{ daal_version }}/download/{{ target_platform }}/daal-include-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-include
+    sha256: {{ daal_include_hash }}
   - url: https://anaconda.org/intel/daal-static/{{ daal_version }}/download/{{ target_platform }}/daal-static-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-static
+    sha256: {{ daal_static_hash }}
   - url: https://anaconda.org/intel/daal-devel/{{ daal_version }}/download/{{ target_platform }}/daal-devel-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-devel
+    sha256: {{ daal_devel_hash }}
 
 build:
   number: {{ mkl_buildnum|int + build_number_bump|int }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,24 +5,30 @@
 {% set mkl_buildnum = "223" %}          # [linux]
 {% set openmp_version = mkl_version %}  # [linux]
 {% set openmp_buildnum = "3768" %}      # [linux]
-{% set daal_version = "2021.6.0" %}     # [linux]
-{% set daal_buildnum = "915" %}         # [linux]
+{% set dal_version = "2021.6.0" %}      # [linux]
+{% set dal_buildnum = "915" %}          # [linux]
+{% set daal_version = "2021.5.3" %}     # [linux]
+{% set daal_buildnum = "815" %}         # [linux]
 
 # OSX
 {% set mkl_version = "2022.1.0" %}      # [osx]
 {% set mkl_buildnum = "208" %}          # [osx]
 {% set openmp_version = mkl_version %}  # [osx]
 {% set openmp_buildnum = "3718" %}      # [osx]
-{% set daal_version = "2021.6.0" %}     # [osx]
-{% set daal_buildnum = "928" %}         # [osx]
+{% set dal_version = "2021.6.0" %}      # [osx]
+{% set dal_buildnum = "928" %}          # [osx]
+{% set daal_version = "2021.5.0" %}     # [osx]
+{% set daal_buildnum = "782" %}         # [osx]
 
 # Windows
 {% set mkl_version = "2022.1.0" %}      # [win]
 {% set mkl_buildnum = "192" %}          # [win]
 {% set openmp_version = mkl_version %}  # [win]
 {% set openmp_buildnum = "3787" %}      # [win]
-{% set daal_version = "2021.6.0" %}     # [win]
-{% set daal_buildnum = "874" %}         # [win]
+{% set dal_version = "2021.6.0" %}      # [win]
+{% set dal_buildnum = "874" %}          # [win]
+{% set daal_version = "2021.5.4" %}     # [win]
+{% set daal_buildnum = "854" %}         # [win]
 
 
 # We will use the <X>_buildnumber for the package buildnumber; however, when it's necessary to bump
@@ -44,13 +50,13 @@ source:
     folder: mkl-include
   - url: https://anaconda.org/intel/intel-openmp/{{ openmp_version }}/download/{{ target_platform }}/intel-openmp-{{ openmp_version }}-intel_{{ openmp_buildnum }}.tar.bz2
     folder: intel-openmp
-  - url: https://anaconda.org/intel/dal/{{ daal_version }}/download/{{ target_platform }}/dal-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/dal/{{ dal_version }}/download/{{ target_platform }}/dal-{{ dal_version }}-intel_{{ dal_buildnum }}.tar.bz2
     folder: dal
-  - url: https://anaconda.org/intel/dal-include/{{ daal_version }}/download/{{ target_platform }}/dal-include-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/dal-include/{{ dal_version }}/download/{{ target_platform }}/dal-include-{{ dal_version }}-intel_{{ dal_buildnum }}.tar.bz2
     folder: dal-include
-  - url: https://anaconda.org/intel/dal-static/{{ daal_version }}/download/{{ target_platform }}/dal-static-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/dal-static/{{ dal_version }}/download/{{ target_platform }}/dal-static-{{ dal_version }}-intel_{{ dal_buildnum }}.tar.bz2
     folder: dal-static
-  - url: https://anaconda.org/intel/dal-devel/{{ daal_version }}/download/{{ target_platform }}/dal-devel-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
+  - url: https://anaconda.org/intel/dal-devel/{{ dal_version }}/download/{{ target_platform }}/dal-devel-{{ dal_version }}-intel_{{ dal_buildnum }}.tar.bz2
     folder: dal-devel
   - url: https://anaconda.org/intel/daal/{{ daal_version }}/download/{{ target_platform }}/daal-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal
@@ -230,11 +236,11 @@ outputs:
         - ls -A $PREFIX/include/*  # [unix]
 
   - name: dal
-    version: {{ daal_version }}
+    version: {{ dal_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      number: {{ daal_buildnum|int + build_number_bump|int }}
+      number: {{ dal_buildnum|int + build_number_bump|int }}
       binary_relocation: false
       detect_binary_files_with_prefix: false
       skip: True                                  # [win32]
@@ -281,9 +287,9 @@ outputs:
         - $RPATH/svml_dispmd.dll        # [win]
     requirements:
       host:
-        - tbb {{ daal_version.split('.')[0] }}.*
+        - tbb {{ dal_version.split('.')[0] }}.*
       run:
-        - tbb {{ daal_version.split('.')[0] }}.*
+        - tbb {{ dal_version.split('.')[0] }}.*
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
       summary: Intel® oneDAL runtime libraries
@@ -305,11 +311,11 @@ outputs:
         - ls -A $PREFIX/lib/*  # [unix]
 
   - name: dal-include
-    version: {{ daal_version }}
+    version: {{ dal_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      number: {{ daal_buildnum|int + build_number_bump|int }}
+      number: {{ dal_buildnum|int + build_number_bump|int }}
       skip: True                                  # [win32]
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
@@ -332,11 +338,11 @@ outputs:
         - ls -A $PREFIX/include/*  # [unix]
 
   - name: dal-static
-    version: {{ daal_version }}
+    version: {{ dal_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      number: {{ daal_buildnum|int + build_number_bump|int }}
+      number: {{ dal_buildnum|int + build_number_bump|int }}
       skip: True                                  # [win32]
       missing_dso_whitelist:
         - $RPATH/sycld.dll            # [win]
@@ -349,7 +355,7 @@ outputs:
     requirements:
       run:
         - {{ pin_subpackage('dal-include', exact=True) }}
-        - tbb {{ daal_version.split('.')[0] }}.*
+        - tbb {{ dal_version.split('.')[0] }}.*
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
       summary: Static libraries for Intel® oneDAL
@@ -371,11 +377,11 @@ outputs:
         - ls -A $PREFIX/lib/*  # [unix]
 
   - name: dal-devel
-    version: {{ daal_version }}
+    version: {{ dal_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
     build:
-      number: {{ daal_buildnum|int + build_number_bump|int }}
+      number: {{ dal_buildnum|int + build_number_bump|int }}
       skip: True                                  # [win32]
       run_exports:
         - {{ pin_subpackage('dal') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -226,21 +226,21 @@ outputs:
       detect_binary_files_with_prefix: false
       missing_dso_whitelist:
         # tbb: Since tbb version is wildcarded in run, so we need to call it out here:
-        - "$RPATH/libtbb.so.12"
-        - "$RPATH/libtbbmalloc.so.2"
-        # these are contained in Intel's optional common_cmplr_lib_rt (now intel-cmplr-lib-rt).
-        - "$RPATH/libsvml.so"
-        - "$RPATH/libirng.so"
-        - "$RPATH/libimf.so"
-        - "$RPATH/libintlc.so.5"
+        - "$RPATH/libtbb.so.12"           # [linux]
+        - "$RPATH/libtbbmalloc.so.2"      # [linux]
+        # Optional intel-cmplr-lib-rt.
+        - "$RPATH/libimf.so"              # [linux]
+        - "$RPATH/libintlc.so.5"          # [linux]
+        - "$RPATH/libirng.so"             # [linux]
+        - "$RPATH/libsvml.so"             # [linux]
         - "$RPATH/libmmd.dll"             # [win]
         # # this comes from Intel's optional dpcpp_cpp_rt
-        - "$RPATH/libsycl.so.5"
+        - "$RPATH/libsycl.so.5"           # [linux]
         # these two really shouldn't be here.  See mkl_repack_and_patchelf.sh
         - libiomp5.so
         - libcoi_device.so.0
         # hooray, windows
-        - "C:\\Windows\\System32\\WINTRUST.dll"
+        - "C:\\Windows\\System32\\WINTRUST.dll" # [win]
         # optional dpcpp runtime that we do not yet provide.
         - "$RPATH/sycl.dll"               # [win]
         - "$RPATH/svml_dispmd.dll"        # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ build:
   number: {{ mkl_buildnum|int + build_number_bump|int }}
   binary_relocation: false
   detect_binary_files_with_prefix: false
-  skip: True             # [win32 or (not x86) or (not (linux or win or osx))]
+  skip: True             # [not x86_64]
   runpath_whitelist:     # <---------------------------------------------------------------------------------------------------------------------------------   Do a trial remove
     - $ORIGIN
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@
 {% set dal_version = "2021.6.0" %}      # [linux]
 {% set dal_buildnum = "915" %}          # [linux]
 {% set daal_version = "2021.5.3" %}     # [linux]
-{% set daal_buildnum = "815" %}         # [linux]
+{% set daal_buildnum = "832" %}         # [linux]
 
 # OSX
 {% set mkl_version = "2022.1.0" %}      # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -79,7 +79,15 @@ outputs:
   - name: mkl
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
+    build:
+      number: {{ mkl_buildnum|int + build_number_bump|int }}
+      missing_dso_whitelist:
+        # tbb
+        - "$RPATH/libtbb.so.12"
+        - "$RPATH/libtbbmalloc.so.2"
     requirements:
+      build:
+        - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
       host:
         - intel-openmp {{ openmp_version.split('.')[0] }}.*
       run:
@@ -128,10 +136,18 @@ outputs:
       missing_dso_whitelist:
         # OS specific:
         - "$RPATH/libelf.so.1"            # [linux] - OS file.
+        # Optional intel-cmplr-lib-rt
+        - "$RPATH/libimf.so"              # linux - intel-cmplr-lib-rt
+        - "$RPATH/libintlc.so.5"          # linux - intel-cmplr-lib-rt
+        - "$RPATH/libirng.so"             # linux - intel-cmplr-lib-rt
+        - "$RPATH/libirng.so"             # linux - intel-cmplr-lib-rt
+        - "$RPATH/libsvml.so"             # linux - intel-cmplr-lib-rt
         # Optional `intel-opencl-rt`:
         - "$RPATH/libOpenCL.so.1"         # [linux] - optional `intel-opencl-rt`
         # Optional oneAPI Level Zero Loader:
         - "$RPATH/libze_loader.so.1"      # [linux] - optional oneAPI Level Zero loader.
+        # Optional FFI
+        - "$RPATH/libffi.so.6"            # [linux]
         # Others...
 
     requirements:
@@ -141,10 +157,8 @@ outputs:
         - __glibc >=2.17                  # [linux] - intel-openmp 2021.1.1 and newer is built with a newer GLIBC
       host:
         - zlib
-        - libffi
       run:
         - zlib
-        - libffi
     about:
       home: https://software.intel.com/en-us/node/522690
       license: LicenseRef-ProprietaryIntel
@@ -211,6 +225,9 @@ outputs:
       binary_relocation: false
       detect_binary_files_with_prefix: false
       missing_dso_whitelist:
+        # tbb: Since tbb version is wildcarded in run, so we need to call it out here:
+        - "$RPATH/libtbb.so.12"
+        - "$RPATH/libtbbmalloc.so.2"
         # these are contained in Intel's optional common_cmplr_lib_rt (now intel-cmplr-lib-rt).
         - "$RPATH/libsvml.so"
         - "$RPATH/libirng.so"
@@ -228,6 +245,8 @@ outputs:
         - "$RPATH/sycl.dll"               # [win]
         - "$RPATH/svml_dispmd.dll"        # [win]
     requirements:
+      build:
+        - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
       host:
         - tbb {{ dal_version.split('.')[0] }}.*
       run:
@@ -293,6 +312,8 @@ outputs:
         - $RPATH/tbbmalloc_debug.dll  # [win]
         - $RPATH/svml_dispmd.dll      # [win]
     requirements:
+      build:
+        - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
       run:
         - {{ pin_subpackage('dal-include', exact=True) }}
         - tbb {{ dal_version.split('.')[0] }}.*
@@ -325,6 +346,8 @@ outputs:
       run_exports:
         - {{ pin_subpackage('dal') }}
     requirements:
+      build:
+        - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
       run:
         - {{ pin_subpackage('dal-include', exact=True) }}
         - {{ pin_subpackage('dal', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -68,7 +68,7 @@
 {% set daal_hash = "8799109a566c4a3d2f5e3800b5365e639da7f5d6032052020ceed1e801e228f5" %}          # [win]
 {% set daal_include_hash = "ea3ad17eca1ecea588e641706c40fa6895ca3e0f3d10cd9c92e8a6f6ff9865aa" %}  # [win]
 {% set daal_static_hash = "d3db345f3acd4d951e218301f480001b4994a639cb552d326215c8f1594d5c5a" %}   # [win]
-{% set daal_devel_hash = "8799109a566c4a3d2f5e3800b5365e639da7f5d6032052020ceed1e801e228f5" %}    # [win]
+{% set daal_devel_hash = "545b249720c20877a9691fcdb79a1489f0654ae34026308d3b1b5c4ff064b1cd" %}    # [win]
 
 
 # We will use the <X>_buildnumber for the package buildnumber (where x is mkl, dal, etc); however, when it's necessary to bump

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -137,15 +137,16 @@ outputs:
         # OS specific:
         - "$RPATH/libelf.so.1"            # [linux] - OS file.
         # Optional intel-cmplr-lib-rt
-        - "$RPATH/libimf.so"              # linux - intel-cmplr-lib-rt
-        - "$RPATH/libintlc.so.5"          # linux - intel-cmplr-lib-rt
-        - "$RPATH/libirng.so"             # linux - intel-cmplr-lib-rt
-        - "$RPATH/libirng.so"             # linux - intel-cmplr-lib-rt
-        - "$RPATH/libsvml.so"             # linux - intel-cmplr-lib-rt
+        - "$RPATH/libimf.so"              # [linux] - intel-cmplr-lib-rt.
+        - "$RPATH/libintlc.so.5"          # [linux] - intel-cmplr-lib-rt.
+        - "$RPATH/libirng.so"             # [linux] - intel-cmplr-lib-rt.
+        - "$RPATH/libirng.so"             # [linux] - intel-cmplr-lib-rt.
+        - "$RPATH/libsvml.so"             # [linux] - intel-cmplr-lib-rt.
         # Optional `intel-opencl-rt`:
-        - "$RPATH/libOpenCL.so.1"         # [linux] - optional `intel-opencl-rt`
+        - "$RPATH/libOpenCL.so.1"         # [linux] - optional `intel-opencl-rt`.
         # Optional oneAPI Level Zero Loader:
         - "$RPATH/libze_loader.so.1"      # [linux] - optional oneAPI Level Zero loader.
+        - "$RPATH/ze_loader.dll"          # [win]   - optional oneAPI Level Zero loader.
         # Optional FFI
         - "$RPATH/libffi.so.6"            # [linux]
         # Others...

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -72,58 +72,8 @@ build:
   binary_relocation: false
   detect_binary_files_with_prefix: false
   skip: True             # [win32 or (not x86) or (not (linux or win or osx))]
-  runpath_whitelist:
+  runpath_whitelist:     # <---------------------------------------------------------------------------------------------------------------------------------   Do a trial remove
     - $ORIGIN
-  missing_dso_whitelist:
-    # just ignore tbb on mac.  We could add it as a dep when we have it.
-    - libtbb.dylib                   # [osx]
-    - "$RPATH/libtbb.dylib"          # [osx]
-    # this one should be here, probably needs fixup of RUNPATH/RPATH
-    - libiomp5.dylib                   # [osx]
-    - "$RPATH/libiomp5.dylib"          # [osx]
-    # normal linux stuff that would go away if we had libgcc-ng in the run deps
-    - /lib*/ld-linux.so.2
-    - /lib64/ld-linux-x86-64.so.2
-    - /lib*/libpthread.so.0
-    - /lib*/libdl.so.2
-    - /lib*/libgcc_s.so.1
-    - /lib*/libc.so.6
-    - /lib*/libm.so.6
-    - /lib*/libz.so.1
-    - "$RPATH/libtbb.2.so"
-    - "$RPATH/libtbbmalloc.so.1"
-    - /lib64/libstdc++.so.6         # [linux]
-    # these two really shouldn't be here.  See mkl_repack_and_patchelf.sh
-    - libiomp5.so
-    - libcoi_device.so.0
-    - /usr/lib/libstdc++.so.6       # [linux]
-    - /usr/lib64/libstdc++.so.6     # [linux]
-    - /usr/lib/libc++.1.dylib       # [osx]
-    # hooray, windows
-    - "C:\\Windows\\System32\\WINTRUST.dll"
-    # mostly things for optional runtime targets..
-    - $RPATH/libOpenCL.so.1       # [linux]
-    - $RPATH/libffi.so.6          # [linux]
-    - $RPATH/libimf.so            # [linux]
-    - $RPATH/libintlc.so.5        # [linux]
-    - $RPATH/libiomp5.so          # [linux]
-    - $RPATH/libirng.so           # [linux]
-    - $RPATH/libsvml.so           # [linux]
-    - $RPATH/libze_loader.so.1    # [linux]
-    - $RPATH/libtbb.so.12         # [linux]
-    - '**/librt.so.1'             # [linux]
-    - '**/libelf.so.1'            # [linux]
-    - $RPATH/libtbb.12.dylib      # [osx]
-    - $RPATH/ze_loader.dll        # [win]
-    - $RPATH/impi.dll             # [win]
-    - $RPATH/msmpi.dll            # [win]
-    - $RPATH/mpich2mpi.dll        # [win]
-    - $RPATH/pgc.dll              # [win]
-    - $RPATH/pgf90.dll            # [win]
-    - $RPATH/pgmath.dll           # [win]
-    - $RPATH/svml_dispmd.dll      # [win]
-    # We might want to look into this a bit and see if we should update intel-openmp's dependencies?
-    - /lib64/libffi.so.6          # [linux]
 
 outputs:
   - name: mkl
@@ -131,9 +81,9 @@ outputs:
     script: repack.bat  # [win]
     requirements:
       host:
-        - intel-openmp {{ mkl_version.split('.')[0] }}.*
+        - intel-openmp {{ openmp_version.split('.')[0] }}.*
       run:
-        - intel-openmp {{ mkl_version.split('.')[0] }}.*
+        - intel-openmp {{ openmp_version.split('.')[0] }}.*
       run_constrained:      # [linux or osx]
         # intel-openmp 2021.1.1 and newer is built with a newer GLIBC
         - __glibc >=2.17    # [linux]
@@ -170,14 +120,25 @@ outputs:
         - ls -A $PREFIX/include/*  # [unix]
 
   - name: intel-openmp
+    version: {{ openmp_version }}
     script: repack.sh   # [unix]
     script: repack.bat  # [win]
-    number: {{ openmp_buildnum }}
-    version: {{ openmp_version }}
+    build:
+      number: {{ openmp_buildnum|int + build_number_bump|int }}
+      missing_dso_whitelist:
+        # - "$RPATH/libintlc.so.5"
     requirements:           # [linux]
+      build:
+        - {{ compiler('cxx') }}           # [linux] - Compiler added for automatic inclusion of `missing_dso_whitespace` values.
       run_constrained:      # [linux]
-        # intel-openmp 2021.1.1 and newer is built with a newer GLIBC
-        - __glibc >=2.17    # [linux]
+        - __glibc >=2.17    # [linux] - intel-openmp 2021.1.1 and newer is built with a newer GLIBC
+      host:
+        - intel-cmplr-lib-rt
+        - zlib
+      run:
+        - intel-cmplr-lib-rt
+        - intel-opencl-rt
+        - zlib
     about:
       home: https://software.intel.com/en-us/node/522690
       license: LicenseRef-ProprietaryIntel
@@ -243,48 +204,45 @@ outputs:
       number: {{ dal_buildnum|int + build_number_bump|int }}
       binary_relocation: false
       detect_binary_files_with_prefix: false
-      skip: True                                  # [win32]
       ignore_run_exports:   # [linux or win]
         - tbb               # [linux or win]
       missing_dso_whitelist:
-        # just ignore tbb on mac.  We could add it as a dep when we have it.
-        - libtbb.dylib                   # [osx]
-        - "$RPATH/libtbb.dylib"          # [osx]
+        - libtbb.dylib                    # [osx]  just ignore tbb on mac.  We could add
+        # it as a dep when we have it.
+        - "$RPATH/libtbb.dylib"           # [osx]
         # this one should be here, probably needs fixup of RUNPATH/RPATH
-        - libiomp5.dylib                   # [osx]
-        - "$RPATH/libiomp5.dylib"          # [osx]
+        - libiomp5.dylib                  # [osx]
+        - "$RPATH/libiomp5.dylib"         # [osx]
+        - "$RPATH/libc++.1.dylib"         # [osx]
         # normal linux stuff that would go away if we had libgcc-ng in the run deps
-        - /lib*/ld-linux.so.2
-        - /lib64/ld-linux-x86-64.so.2
-        - /lib*/libpthread.so.0
-        - /lib*/libdl.so.2
-        - /lib*/libgcc_s.so.1
-        - /lib*/libc.so.6
-        - /lib*/libm.so.6
-        - lib/libgcc_s.so.1
-        - lib*/libz.so.1
-        - "$RPATH/libtbb.so.12"
-        - "$RPATH/libtbbmalloc.so.2"
-        - /lib64/libstdc++.so.6         # [linux]
+        - "$RPATH/ld-linux-x86-64.so.2"   # [linux]
+        - "$RPATH/ld-linux.so.2"          # [linux]
+        - "$RPATH/libc.so.6"              # [linux]
+        - "$RPATH/libdl.so.2"             # [linux]
+        - "$RPATH/libgcc_s.so.1"          # [linux]
+        - "$RPATH/libm.so.6"              # [linux]
+        - "$RPATH/libpthread.so.0"        # [linux]
+        - "$RPATH/libstdc++.so.6"         # [linux]
+        - "$RPATH/libtbb.so.12"           # [linux]
+        - "$RPATH/libtbbmalloc.so.2"      # [linux]
+        - "$RPATHibgcc_s.so.1"            # [linux]
+        - "$RPATHlibz.so.1"               # [linux]
         # these are contained in Intel's optional common_cmplr_lib_rt (now intel-cmplr-lib-rt).
         - "$RPATH/libsvml.so"
         - "$RPATH/libirng.so"
         - "$RPATH/libimf.so"
         - "$RPATH/libintlc.so.5"
-        - $RPATH/libmmd.dll             # [win]
+        - "$RPATH/libmmd.dll"             # [win]
         # # this comes from Intel's optional dpcpp_cpp_rt
         - "$RPATH/libsycl.so.5"
         # these two really shouldn't be here.  See mkl_repack_and_patchelf.sh
         - libiomp5.so
         - libcoi_device.so.0
-        - /usr/lib/libstdc++.so.6       # [linux]
-        - /usr/lib64/libstdc++.so.6     # [linux]
-        - /usr/lib/libc++.1.dylib       # [osx]
         # hooray, windows
         - "C:\\Windows\\System32\\WINTRUST.dll"
         # optional dpcpp runtime that we do not yet provide.
-        - $RPATH/sycl.dll               # [win]
-        - $RPATH/svml_dispmd.dll        # [win]
+        - "$RPATH/sycl.dll"               # [win]
+        - "$RPATH/svml_dispmd.dll"        # [win]
     requirements:
       host:
         - tbb {{ dal_version.split('.')[0] }}.*
@@ -316,7 +274,6 @@ outputs:
     script: repack.bat  # [win]
     build:
       number: {{ dal_buildnum|int + build_number_bump|int }}
-      skip: True                                  # [win32]
     about:
       home: https://software.intel.com/content/www/us/en/develop/tools.html
       summary: Headers for building against Intel® oneDAL libraries
@@ -343,7 +300,6 @@ outputs:
     script: repack.bat  # [win]
     build:
       number: {{ dal_buildnum|int + build_number_bump|int }}
-      skip: True                                  # [win32]
       missing_dso_whitelist:
         - $RPATH/sycld.dll            # [win]
         - $RPATH/libmmdd.dll          # [win]
@@ -382,7 +338,6 @@ outputs:
     script: repack.bat  # [win]
     build:
       number: {{ dal_buildnum|int + build_number_bump|int }}
-      skip: True                                  # [win32]
       run_exports:
         - {{ pin_subpackage('dal') }}
     requirements:
@@ -420,7 +375,6 @@ outputs:
     version: {{ daal_version }}
     build:
       number: {{ daal_buildnum|int + build_number_bump|int }}
-      skip: True                                  # [win32]
     requirements:
       run:
         - {{ pin_subpackage('dal', max_pin='x') }}
@@ -443,7 +397,6 @@ outputs:
     version: {{ daal_version }}
     build:
       number: {{ daal_buildnum|int + build_number_bump|int }}
-      skip: True                                  # [win32]
     requirements:
       run:
         - {{ pin_subpackage('dal-include', max_pin='x') }}
@@ -466,7 +419,6 @@ outputs:
     version: {{ daal_version }}
     build:
       number: {{ daal_buildnum|int + build_number_bump|int }}
-      skip: True                                  # [win32]
     requirements:
       run:
         - {{ pin_subpackage('dal-static', max_pin='x') }}
@@ -489,7 +441,6 @@ outputs:
     version: {{ daal_version }}
     build:
       number: {{ daal_buildnum|int + build_number_bump|int }}
-      skip: True                                  # [win32]
     requirements:
       run:
         - {{ pin_subpackage('dal-devel', max_pin='x') }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -457,16 +457,14 @@ outputs:
       license: Intel Simplified Software License
       license_family: Proprietary
       license_file:
-         - dal-devel/licenses/license.txt       # [osx]
-         - dal-devel/licenses/tpp.txt           # [osx]
-         - dal-devel/info/licenses/license.txt  # [not osx]
-         - dal-devel/info/licenses/tpp.txt      # [not osx]
+         - dal-devel/info/licenses/license.txt
+         - dal-devel/info/licenses/tpp.txt
       license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
       dev_url: https://github.com/oneapi-src/oneDAL
     test:
       commands:
-        - ls -A $PREFIX/lib/*  # [unix]
+        - ls -A $PREFIX/lib/*      # [unix]
         - ls -A $PREFIX/include/*  # [unix]
 
 # please the linter

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -147,7 +147,7 @@ outputs:
 
     requirements:
       build:
-        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
       host:
         - intel-openmp {{ openmp_version.split('.')[0] }}.*
       run:
@@ -213,7 +213,7 @@ outputs:
 
     requirements:
       build:
-        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
       run_constrained:                    # [linux]
         - __glibc >=2.17                  # [linux] - intel-openmp 2021.1.1 and newer is built with a newer GLIBC
       host:
@@ -310,7 +310,7 @@ outputs:
         - "$RPATH/svml_dispmd.dll"        # [win]
     requirements:
       build:
-        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
       host:
         - tbb {{ dal_version.split('.')[0] }}.*
       run:
@@ -377,7 +377,7 @@ outputs:
         - $RPATH/svml_dispmd.dll      # [win]
     requirements:
       build:
-        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
       run:
         - {{ pin_subpackage('dal-include', exact=True) }}
         - tbb {{ dal_version.split('.')[0] }}.*
@@ -411,7 +411,7 @@ outputs:
         - {{ pin_subpackage('dal') }}
     requirements:
       build:
-        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
       run:
         - {{ pin_subpackage('dal-include', exact=True) }}
         - {{ pin_subpackage('dal', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -65,7 +65,7 @@
 {% set dal_include_hash = "15867d2f83d26e21468c178b8760de12534b267eae8a46f439d8427cd7b469ef" %}   # [win]
 {% set dal_static_hash = "e7045f200522fcd5fd471072aeed1ca4df9ad06617feadb9040e5b2c55bfbced" %}    # [win]
 {% set dal_devel_hash = "7da9f5964534256e44eb1e8d1bdcad9950763d524b4cf66aa85847f422700714" %}     # [win]
-{% set daal_hash = "d3db345f3acd4d951e218301f480001b4994a639cb552d326215c8f1594d5c5a" %}          # [win]
+{% set daal_hash = "8799109a566c4a3d2f5e3800b5365e639da7f5d6032052020ceed1e801e228f5" %}          # [win]
 {% set daal_include_hash = "ea3ad17eca1ecea588e641706c40fa6895ca3e0f3d10cd9c92e8a6f6ff9865aa" %}  # [win]
 {% set daal_static_hash = "d3db345f3acd4d951e218301f480001b4994a639cb552d326215c8f1594d5c5a" %}   # [win]
 {% set daal_devel_hash = "8799109a566c4a3d2f5e3800b5365e639da7f5d6032052020ceed1e801e228f5" %}    # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -156,9 +156,9 @@ outputs:
       run_constrained:                    # [linux]
         - __glibc >=2.17                  # [linux] - intel-openmp 2021.1.1 and newer is built with a newer GLIBC
       host:
-        - zlib
+        - zlib                            # [linux]
       run:
-        - zlib
+        - zlib                            # [linux]
     about:
       home: https://software.intel.com/en-us/node/522690
       license: LicenseRef-ProprietaryIntel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -4,7 +4,7 @@
 {% set mkl_version = "2022.1.0" %}      # [linux]
 {% set mkl_buildnum = "223" %}          # [linux]
 {% set openmp_version = mkl_version %}  # [linux]
-{% set openmp_buildnum = "3633" %}      # [linux]
+{% set openmp_buildnum = "3768" %}      # [linux]
 {% set daal_version = "2021.6.0" %}     # [linux]
 {% set daal_buildnum = "915" %}         # [linux]
 
@@ -12,7 +12,7 @@
 {% set mkl_version = "2022.1.0" %}      # [osx]
 {% set mkl_buildnum = "208" %}          # [osx]
 {% set openmp_version = mkl_version %}  # [osx]
-{% set openmp_buildnum = "3615" %}      # [osx]
+{% set openmp_buildnum = "3718" %}      # [osx]
 {% set daal_version = "2021.6.0" %}     # [osx]
 {% set daal_buildnum = "928" %}         # [osx]
 
@@ -20,7 +20,7 @@
 {% set mkl_version = "2022.1.0" %}      # [win]
 {% set mkl_buildnum = "192" %}          # [win]
 {% set openmp_version = mkl_version %}  # [win]
-{% set openmp_buildnum = "3663" %}      # [win]
+{% set openmp_buildnum = "3787" %}      # [win]
 {% set daal_version = "2021.6.0" %}     # [win]
 {% set daal_buildnum = "874" %}         # [win]
 
@@ -35,42 +35,31 @@ package:
   version: {{ mkl_version }}
 
 source:
+  # Conscider adding sha256 fields here.
   - url: https://anaconda.org/intel/mkl/{{ mkl_version }}/download/{{ target_platform }}/mkl-{{ mkl_version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl
-    sha256: 1
   - url: https://anaconda.org/intel/mkl-devel/{{ mkl_version }}/download/{{ target_platform }}/mkl-devel-{{ mkl_version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl-devel
-    sha256: 1
   - url: https://anaconda.org/intel/mkl-include/{{ mkl_version }}/download/{{ target_platform }}/mkl-include-{{ mkl_version }}-intel_{{ mkl_buildnum }}.tar.bz2
     folder: mkl-include
-    sha256: 1
   - url: https://anaconda.org/intel/intel-openmp/{{ openmp_version }}/download/{{ target_platform }}/intel-openmp-{{ openmp_version }}-intel_{{ openmp_buildnum }}.tar.bz2
     folder: intel-openmp
-    sha256: 1
   - url: https://anaconda.org/intel/dal/{{ daal_version }}/download/{{ target_platform }}/dal-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: dal
-    sha256: 1
   - url: https://anaconda.org/intel/dal-include/{{ daal_version }}/download/{{ target_platform }}/dal-include-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: dal-include
-    sha256: 1
   - url: https://anaconda.org/intel/dal-static/{{ daal_version }}/download/{{ target_platform }}/dal-static-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: dal-static
-    sha256: 1
   - url: https://anaconda.org/intel/dal-devel/{{ daal_version }}/download/{{ target_platform }}/dal-devel-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: dal-devel
-    sha256: 1
   - url: https://anaconda.org/intel/daal/{{ daal_version }}/download/{{ target_platform }}/daal-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal
-    sha256: 1
   - url: https://anaconda.org/intel/daal-include/{{ daal_version }}/download/{{ target_platform }}/daal-include-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-include
-    sha256: 1
   - url: https://anaconda.org/intel/daal-static/{{ daal_version }}/download/{{ target_platform }}/daal-static-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-static
-    sha256: 1
   - url: https://anaconda.org/intel/daal-devel/{{ daal_version }}/download/{{ target_platform }}/daal-devel-{{ daal_version }}-intel_{{ daal_buildnum }}.tar.bz2
     folder: daal-devel
-    sha256: 1
 
 build:
   number: {{ mkl_buildnum|int + build_number_bump|int }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@
 {% set openmp_version = mkl_version %}  # [linux]
 {% set openmp_buildnum = "3768" %}      # [linux]
 {% set daal_version = "2021.6.0" %}     # [linux]
-{% set daal_buildnum = "928" %}         # [linux]
+{% set daal_buildnum = "915" %}         # [linux]
 
 # OSX
 {% set mkl_version = "2022.1.0" %}      # [osx]
@@ -14,7 +14,7 @@
 {% set openmp_version = mkl_version %}  # [osx]
 {% set openmp_buildnum = "3718" %}      # [osx]
 {% set daal_version = "2021.6.0" %}     # [osx]
-{% set daal_buildnum = "915" %}         # [osx]
+{% set daal_buildnum = "928" %}         # [osx]
 
 # Windows
 {% set mkl_version = "2022.1.0" %}      # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,8 +83,16 @@ outputs:
       number: {{ mkl_buildnum|int + build_number_bump|int }}
       missing_dso_whitelist:
         # tbb
-        - "$RPATH/libtbb.so.12"
-        - "$RPATH/libtbbmalloc.so.2"
+        - "$RPATH/libtbb.so.12"           # [unix]
+        - "$RPATH/libtbbmalloc.so.2"      # [unix]
+        # oneAPI ?
+        - "$RPATH/impi.dll"               # [win]
+        - "$RPATH/msmpi.dll"              # [win]
+        # PGI tools?
+        - "$RPATH/pgc.dll"                # [win]
+        - "$RPATH/pgf90.dll"              # [win]
+        - "$RPATH/pgmath.dll"             # [win]
+
     requirements:
       build:
         - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitespace` values.
@@ -149,7 +157,6 @@ outputs:
         - "$RPATH/ze_loader.dll"          # [win]   - optional oneAPI Level Zero loader.
         # Optional FFI
         - "$RPATH/libffi.so.6"            # [linux]
-        # Others...
 
     requirements:
       build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,7 +71,7 @@ build:
   number: {{ mkl_buildnum|int + build_number_bump|int }}
   binary_relocation: false
   detect_binary_files_with_prefix: false
-  skip: True             # [not x86_64]
+  skip: True             # [not (x86 and (linux or win or osx))]
   runpath_whitelist:     # <---------------------------------------------------------------------------------------------------------------------------------   Do a trial remove
     - $ORIGIN
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,8 +83,9 @@ outputs:
       number: {{ mkl_buildnum|int + build_number_bump|int }}
       missing_dso_whitelist:
         # tbb
-        - "$RPATH/libtbb.so.12"           # [unix]
-        - "$RPATH/libtbbmalloc.so.2"      # [unix]
+        - "$RPATH/libtbb.so.12"           # [linux]
+        - "$RPATH/libtbbmalloc.so.2"      # [linux]
+        - "$RPATH/libtbb.12.dylib"        # [osx]
         # oneAPI ?
         - "$RPATH/impi.dll"               # [win]
         - "$RPATH/msmpi.dll"              # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -362,16 +362,14 @@ outputs:
       license: Intel Simplified Software License
       license_family: Proprietary
       license_file:
-         - dal-devel/licenses/license.txt       # [osx]
-         - dal-devel/licenses/tpp.txt           # [osx]
-         - dal-devel/info/licenses/license.txt  # [not osx]
-         - dal-devel/info/licenses/tpp.txt      # [not osx]
+         - dal-devel/info/licenses/license.txt
+         - dal-devel/info/licenses/tpp.txt
       license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
       doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
       dev_url: https://github.com/oneapi-src/oneDAL
     test:
       commands:
-        - ls -A $PREFIX/lib/*  # [unix]
+        - ls -A $PREFIX/lib/*      # [unix]
         - ls -A $PREFIX/include/*  # [unix]
 
 # Future note: all daal packages are now metapackages that depend on their respective dal equivalent.

--- a/recipe/repack.bat
+++ b/recipe/repack.bat
@@ -1,3 +1,4 @@
+echo "Building %PKG_NAME%."
 set "src=%SRC_DIR%\%PKG_NAME%"
 
 @REM @REM The license files are no longer manually packed but are included via the meta.yaml

--- a/recipe/repack.sh
+++ b/recipe/repack.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+echo "Building ${PKG_NAME}."
 set -ex
 
 # for subpackages, we have named our extracted locations according to the subpackage name


### PR DESCRIPTION
# Changes
- Update versions to latest.
- Reorganize order to be OS specific.
- Reduce `missing_dso_whitespace` entries using compilers in build sections.
- Move global settings into specific outputs.
- Add sha256 hashes.

# Review Info
## Source
 Various
 
 ## License
 Proprietary
 
 # Jira
 https://anaconda.atlassian.net/browse/DSNC-5191
 