### PR TITLE
fix win and linux mkl-devel packages

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,8 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
   - "--error-overdepending"
+
+channels:
+  cbouss: temp
+
+upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,8 +3,3 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
   - "--error-overdepending"
-
-channels:
-  cbouss: temp
-
-upload_without_merge: True

--- a/recipe/install-devel.bat
+++ b/recipe/install-devel.bat
@@ -1,3 +1,6 @@
+@echo on
+setlocal enabledelayedexpansion
+
 set "src=%SRC_DIR%\%PKG_NAME%"
 COPY "%src%\info\licenses\LICENSE.txt" "%SRC_DIR%"
 
@@ -10,8 +13,12 @@ robocopy /E "%src%" "%PREFIX%"
 if %ERRORLEVEL% GEQ 8 exit 1
 
 :: correct .pc files that point to intel64 lib dir instead of just lib
-sed -i.bak -E "s|libdir=(.*)/intel64|libdir=\1|g" %PREFIX%\Library\lib\pkgconfig\*.pc
-del "%PREFIX%\Library\lib\pkgconfig\*.pc.bak"
+for /r "%PREFIX%\Library\lib\pkgconfig\" %%i in (*.pc) do (
+	sed -i.bak -E "s|libdir=(.*)/intel64|libdir=\1|g" "%%i"
+	if errorlevel 1 exit 1
+	del "%%i.bak"
+	type "%%i"
+)
 
 :: replace old info folder with our new regenerated one
 rd /s /q %PREFIX%\info

--- a/recipe/install-devel.bat
+++ b/recipe/install-devel.bat
@@ -9,5 +9,9 @@ echo include_dirs = %LIBRARY_INC%  >> %PREFIX%\site.cfg
 robocopy /E "%src%" "%PREFIX%"
 if %ERRORLEVEL% GEQ 8 exit 1
 
+:: correct .pc files that point to intel64 lib dir instead of just lib
+sed -i.bak -E "s|libdir=(.*)/intel64|libdir=\1|g" %PREFIX%\Library\lib\pkgconfig\*.pc
+del "%PREFIX%\Library\lib\pkgconfig\*.pc.bak"
+
 :: replace old info folder with our new regenerated one
 rd /s /q %PREFIX%\info

--- a/recipe/install-devel.sh
+++ b/recipe/install-devel.sh
@@ -9,5 +9,11 @@ cp $RECIPE_DIR/site.cfg $PREFIX/site.cfg
 echo library_dirs = $PREFIX/lib  >> $PREFIX/site.cfg
 echo include_dirs = $PREFIX/include  >> $PREFIX/site.cfg
 
-cp -rv $SRC_DIR/$PKG_NAME/ $PREFIX
+if [[ "${target_platform}" == "linux-64" ]]; then
+    # mkl-devel 2023.1.0 b0 is not packaged correctly on linux-64
+    cp -rv $SRC_DIR/$PKG_NAME/$PKG_NAME/ $PREFIX
+else
+    cp -rv $SRC_DIR/$PKG_NAME/ $PREFIX
+fi
+
 rm -rf $PREFIX/info

--- a/recipe/install-devel.sh
+++ b/recipe/install-devel.sh
@@ -19,7 +19,7 @@ echo include_dirs = $PREFIX/include  >> $PREFIX/site.cfg
 cp -rv "$src"/* "$PREFIX/"
 
 # correct .pc files that point to intel64 lib dir instead of just lib
-find "$PREFIX/lib/pkgconfig/" -type f -name '*.pc' -exec sed -i 's,libdir=\(.*\)/intel64,libdir=\1,g' {} +
+find "$PREFIX/lib/pkgconfig/" -type f -name '*.pc' -exec sed -i -e 's,libdir=\(.*\)/intel64,libdir=\1,g' {} +
 
 # replace old info folder with our new regenerated one
 rm -rf "$PREFIX/info"

--- a/recipe/install-devel.sh
+++ b/recipe/install-devel.sh
@@ -1,13 +1,22 @@
 #!/bin/bash
+echo "Building ${PKG_NAME}."
+set -ex
+
+# for subpackages, we have named our extracted locations according to the subpackage name
+#    That's what this $PKG_NAME is doing - picking the right subfolder to rsync
+
+src="$SRC_DIR/$PKG_NAME"
 
 # not all packages have the license file.  Copy it from mkl, where we know it exists
-cp -f $SRC_DIR/mkl/info/licenses/license.txt $SRC_DIR
+cp -f "$SRC_DIR/mkl/info/licenses/license.txt" "$SRC_DIR"
 # ro by default.  Makes installations not cleanly removable.
-chmod 664 $SRC_DIR/license.txt
+chmod 664 "$SRC_DIR/license.txt"
 
 cp $RECIPE_DIR/site.cfg $PREFIX/site.cfg
 echo library_dirs = $PREFIX/lib  >> $PREFIX/site.cfg
 echo include_dirs = $PREFIX/include  >> $PREFIX/site.cfg
 
-cp -rv $SRC_DIR/$PKG_NAME/ $PREFIX
-rm -rf $PREFIX/info
+cp -rv "$src"/* "$PREFIX/"
+
+# replace old info folder with our new regenerated one
+rm -rf "$PREFIX/info"

--- a/recipe/install-devel.sh
+++ b/recipe/install-devel.sh
@@ -9,11 +9,5 @@ cp $RECIPE_DIR/site.cfg $PREFIX/site.cfg
 echo library_dirs = $PREFIX/lib  >> $PREFIX/site.cfg
 echo include_dirs = $PREFIX/include  >> $PREFIX/site.cfg
 
-if [[ "${target_platform}" == "linux-64" ]]; then
-    # mkl-devel 2023.1.0 b0 is not packaged correctly on linux-64
-    cp -rv $SRC_DIR/$PKG_NAME/$PKG_NAME/ $PREFIX
-else
-    cp -rv $SRC_DIR/$PKG_NAME/ $PREFIX
-fi
-
+cp -rv $SRC_DIR/$PKG_NAME/ $PREFIX
 rm -rf $PREFIX/info

--- a/recipe/install-devel.sh
+++ b/recipe/install-devel.sh
@@ -18,5 +18,8 @@ echo include_dirs = $PREFIX/include  >> $PREFIX/site.cfg
 
 cp -rv "$src"/* "$PREFIX/"
 
+# correct .pc files that point to intel64 lib dir instead of just lib
+find "$PREFIX/lib/pkgconfig/" -type f -name '*.pc' -exec sed -i 's,libdir=\(.*\)/intel64,libdir=\1,g' {} +
+
 # replace old info folder with our new regenerated one
 rm -rf "$PREFIX/info"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -220,7 +220,7 @@ outputs:
       commands:
         - IF NOT EXIST %PREFIX%\Library\lib\mkl*dll.lib EXIT /B 1  # [win]
         # Verify that the mkl library can be located through pkg-config
-        - test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/libmkl_rt.so  # [unix]
+        - test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/libmkl_rt${SHLIB_EXT}  # [unix]
         - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
       requires:
         - pkg-config

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -220,8 +220,10 @@ outputs:
       commands:
         - IF NOT EXIST %PREFIX%\Library\lib\mkl*dll.lib EXIT /B 1  # [win]
         # Verify that the mkl library can be located through pkg-config
-        #- test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/mkl_rt.so  # [unix]
-        #- for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
+        - test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/libmkl_rt.so  # [unix]
+        - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
+      requires:
+        - pkg-config
     about:
       home: https://software.intel.com/en-us/mkl
       summary: Metapackage of MKL headers and libraries for developing software that uses MKL

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -220,8 +220,8 @@ outputs:
       commands:
         - IF NOT EXIST %PREFIX%\Library\lib\mkl*dll.lib EXIT /B 1  # [win]
         # Verify that the mkl library can be located through pkg-config
-       - test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/mkl_rt.so  # [unix]
-       - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=includedir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
+        #- test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/mkl_rt.so  # [unix]
+        #- for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
     about:
       home: https://software.intel.com/en-us/mkl
       summary: Metapackage of MKL headers and libraries for developing software that uses MKL

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,6 +82,8 @@
 {% set openmp_buildnum = openmp_fetch_buildnum|int + bump_all_buildnum|int + bump_openmp_buildnum|int %}
 {% set dal_buildnum = dal_fetch_buildnum|int + bump_all_buildnum|int + bump_dal_buildnum|int %}
 
+{% set mkldevel_buildnum = mkl_buildnum|int + 1 %}
+
 
 package:
   name: intel_repack
@@ -200,7 +202,7 @@ outputs:
     script: install-devel.sh   # [unix]
     script: install-devel.bat  # [win]
     build:
-      number: {{ mkl_buildnum }}
+      number: {{ mkldevel_buildnum }}
       # when stuff is built with MKL, ensure that constraint makes mkl runtime libs as new or
       #     newer than build version
       run_exports:
@@ -210,6 +212,8 @@ outputs:
         # various downstreams (mkl_fft, mkl_random) to include the mkl-service wrapper as a dependency.
         - mkl-service >=2.3.0,<3.0a0
     requirements:
+      build:
+        - m2-sed  # [win]
       run:
         - {{ pin_subpackage('mkl', exact=True) }}
         - {{ pin_subpackage('mkl-include', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -219,8 +219,9 @@ outputs:
     test:
       commands:
         - IF NOT EXIST %PREFIX%\Library\lib\mkl*dll.lib EXIT /B 1  # [win]
-        # Version 2023.1.0-intel_46342 for linux-64 and 2023.1.0-intel_43558 for osx-64 no .dll or .lib files are included,
-        # since the lib folder does exist on all platforms (but it only has pkgconfig files for osx-64 and linux-64).
+        # Verify that the mkl library can be located through pkg-config
+       - test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/mkl_rt.so  # [unix]
+       - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=includedir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
     about:
       home: https://software.intel.com/en-us/mkl
       summary: Metapackage of MKL headers and libraries for developing software that uses MKL

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@
 # Bump all build numbers here. (Note: it may be appropriate to use selectors here.)
 {% set bump_all_buildnum = "0" %}
 # Bump specific package build numbers here. (Note: it may be appropriate to use selectors here.)
-{% set bump_mkl_buildnum = "0" %}
+{% set bump_mkl_buildnum = "1" %}
 {% set bump_openmp_buildnum = "0" %}
 {% set bump_dal_buildnum = "0" %}
 
@@ -81,8 +81,6 @@
 {% set mkl_buildnum = mkl_fetch_buildnum|int + bump_all_buildnum|int + bump_mkl_buildnum|int %}
 {% set openmp_buildnum = openmp_fetch_buildnum|int + bump_all_buildnum|int + bump_openmp_buildnum|int %}
 {% set dal_buildnum = dal_fetch_buildnum|int + bump_all_buildnum|int + bump_dal_buildnum|int %}
-
-{% set mkldevel_buildnum = mkl_buildnum|int + 1 %}
 
 
 package:
@@ -202,7 +200,7 @@ outputs:
     script: install-devel.sh   # [unix]
     script: install-devel.bat  # [win]
     build:
-      number: {{ mkldevel_buildnum }}
+      number: {{ mkl_buildnum }}
       # when stuff is built with MKL, ensure that constraint makes mkl runtime libs as new or
       #     newer than build version
       run_exports:


### PR DESCRIPTION
Changes:
- mkl-devel win-64 pc files were including the wrong path.
- mkl-devel linux-64 was having pc files in the wrong folder.

This was noticed when building scipy with meson.
I will only upload mkl and mkl-devel.