### PR TITLE
Generate import library for libiomp5md on Windows

### DIFF
--- a/recipe/dll2lib.bat
+++ b/recipe/dll2lib.bat
@@ -1,0 +1,42 @@
+REM Usage: dll2lib [32|64] some-file.dll
+REM
+REM Generates some-file.lib from some-file.dll, making an intermediate
+REM some-file.def from the results of dumpbin /exports some-file.dll.
+REM Currently must run without path on DLL.
+REM (Fix by removing path when of lib_name for LIBRARY line below?)
+REM
+REM Requires 'dumpbin' and 'lib' in PATH - run from VS developer prompt.
+REM
+REM Script inspired by http://stackoverflow.com/questions/9946322/how-to-generate-an-import-library-lib-file-from-a-dll
+REM Taken from https://stackoverflow.com/a/37760062
+SETLOCAL
+if "%1"=="32" (set machine=x86) else (set machine=x64)
+set dll_file=%2
+set dll_file_no_ext=%dll_file:~0,-4%
+set exports_file=%dll_file_no_ext%-exports.txt
+set def_file=%dll_file_no_ext%.def
+set lib_file=%dll_file_no_ext%_dll.lib
+set lib_name=%dll_file_no_ext%
+
+dumpbin /exports %dll_file% > %exports_file%
+if %ERRORLEVEL% GEQ 1 exit 1
+
+echo LIBRARY %lib_name% > %def_file%
+echo EXPORTS >> %def_file%
+for /f "skip=19 tokens=1,4" %%A in (%exports_file%) do if NOT "%%B" == "" (echo %%B @%%A >> %def_file%)
+
+lib /def:%def_file% /out:%lib_file% /machine:%machine%
+if %ERRORLEVEL% GEQ 1 exit 1
+
+echo "Generated %cwd%\%lib_file%"
+
+REM Clean up temporary intermediate files
+del %exports_file% %def_file% %dll_file_no_ext%.exp
+
+set cwd=%cd%
+
+echo "Moving '%cwd%\%lib_file%' to '%LIBRARY_PREFIX%\lib\%lib_file%'"
+mv %lib_file% %LIBRARY_PREFIX%\lib\%lib_file%
+if %ERRORLEVEL% GEQ 1 "failed to move '%cwd%\%lib_file%' to '%LIBRARY_PREFIX%\lib\%lib_file%'" & exit 1
+
+exit 0

--- a/recipe/dll2lib.bat
+++ b/recipe/dll2lib.bat
@@ -15,7 +15,7 @@ set dll_file=%2
 set dll_file_no_ext=%dll_file:~0,-4%
 set exports_file=%dll_file_no_ext%-exports.txt
 set def_file=%dll_file_no_ext%.def
-set lib_file=%dll_file_no_ext%_dll.lib
+set lib_file=%dll_file_no_ext%.lib
 set lib_name=%dll_file_no_ext%
 
 dumpbin /exports %dll_file% > %exports_file%

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -230,8 +230,9 @@ outputs:
         - test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/libmkl_rt${SHLIB_EXT}  # [unix]
         - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
         - cmake -S tests/mkl-devel -B build -G Ninja -DCMAKE_VERBOSE_MAKEFILE=ON
-        - cmake --build build
-        - cd build && ctest
+        - cmake --build build -v
+        - cd build && ctest  # [not win]
+        - cd build\Debug && ctest  # [win]
     about:
       home: https://software.intel.com/en-us/mkl
       summary: Metapackage of MKL headers and libraries for developing software that uses MKL
@@ -279,7 +280,7 @@ outputs:
         - test -f $PREFIX/lib/libomptarget${SHLIB_EXT}                    # [linux]
         - IF NOT EXIST %PREFIX%\Library\bin\libiomp*.dll EXIT /B 1        # [win]
         - IF NOT EXIST %PREFIX%\Library\bin\omp*.dll EXIT /B 1            # [win]
-        - IF NOT EXIST %PREFIX%\Library\lib\libiomp5md_dll.lib echo "%PREFIX%\Library\lib\libiomp5md_dll.lib is missing" & EXIT /B 1  # [win]
+        - IF NOT EXIST %PREFIX%\Library\lib\libiomp5md.lib echo "%PREFIX%\Library\lib\libiomp5md.lib is missing" & EXIT /B 1  # [win]
     about:
       home: https://software.intel.com/en-us/node/522690
       license: LicenseRef-ProprietaryIntel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,18 +102,18 @@ source:
   - url: https://anaconda.org/intel/intel-openmp/{{ openmp_version }}/download/{{ target_platform }}/intel-openmp-{{ openmp_version }}-intel_{{ openmp_fetch_buildnum }}.tar.bz2
     folder: intel-openmp
     sha256: {{ intel_openmp_hash }}
-  - url: https://anaconda.org/intel/dal/{{ dal_version }}/download/{{ target_platform }}/dal-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
-    folder: dal
-    sha256: {{ dal_hash }}
-  - url: https://anaconda.org/intel/dal-include/{{ dal_version }}/download/{{ target_platform }}/dal-include-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
-    folder: dal-include
-    sha256: {{ dal_include_hash }}
-  - url: https://anaconda.org/intel/dal-static/{{ dal_version }}/download/{{ target_platform }}/dal-static-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
-    folder: dal-static
-    sha256: {{ dal_static_hash }}
-  - url: https://anaconda.org/intel/dal-devel/{{ dal_version }}/download/{{ target_platform }}/dal-devel-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
-    folder: dal-devel
-    sha256: {{ dal_devel_hash }}
+  # - url: https://anaconda.org/intel/dal/{{ dal_version }}/download/{{ target_platform }}/dal-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
+  #   folder: dal
+  #   sha256: {{ dal_hash }}
+  # - url: https://anaconda.org/intel/dal-include/{{ dal_version }}/download/{{ target_platform }}/dal-include-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
+  #   folder: dal-include
+  #   sha256: {{ dal_include_hash }}
+  # - url: https://anaconda.org/intel/dal-static/{{ dal_version }}/download/{{ target_platform }}/dal-static-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
+  #   folder: dal-static
+  #   sha256: {{ dal_static_hash }}
+  # - url: https://anaconda.org/intel/dal-devel/{{ dal_version }}/download/{{ target_platform }}/dal-devel-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
+  #   folder: dal-devel
+  #   sha256: {{ dal_devel_hash }}
 
 build:
   number: {{ mkl_buildnum }}
@@ -311,185 +311,185 @@ outputs:
       license_file: ANACONDA_LICENSE
       summary: 'BLAS mutex for MKL'
 
-  - name: dal
-    version: {{ dal_version }}
-    script: repack.sh   # [unix]
-    script: repack.bat  # [win]
-    build:
-      number: {{ dal_buildnum }}
-      binary_relocation: false
-      detect_binary_files_with_prefix: false
-      missing_dso_whitelist:
-        # tbb: Since tbb version is wildcarded in run, so we need to call it out here:
-        - "$RPATH/libtbb.so.12"           # [linux]
-        - "$RPATH/libtbbmalloc.so.2"      # [linux]
-        # Optional intel-cmplr-lib-rt.
-        - "$RPATH/libimf.so"              # [linux]
-        - "$RPATH/libintlc.so.5"          # [linux]
-        - "$RPATH/libirng.so"             # [linux]
-        - "$RPATH/libsvml.so"             # [linux]
-        - "$RPATH/libmmd.dll"             # [win]
-        # Optional `intel-opencl-rt`:
-        - "$RPATH/libOpenCL.so.1"         # [linux]
-        - "$RPATH/OpenCL.dll"             # [win]
-        # # this comes from Intel's optional dpcpp_cpp_rt
-        - "$RPATH/libsycl.so.6"           # [linux]
-        # these two really shouldn't be here.  See mkl_repack_and_patchelf.sh
-        - libiomp5.so
-        - libcoi_device.so.0
-        # hooray, windows
-        - "C:\\Windows\\System32\\WINTRUST.dll" # [win]
-        # optional dpcpp runtime that we do not yet provide.
-        - "$RPATH/sycl6.dll"              # [win]
-        - "$RPATH/svml_dispmd.dll"        # [win]
-    requirements:
-      build:
-        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
-      host:
-        - tbb {{ tbb_version.split('.')[0] }}.*
-      run:
-        - tbb {{ tbb_version.split('.')[0] }}.*
-    test:
-      commands:
-        - test -f $PREFIX/lib/libonedal.so.1                       # [linux]
-        - test -f $PREFIX/lib/libonedal_core.so.1                  # [linux]
-        - test -f $PREFIX/lib/libonedal_dpc.so.1                   # [linux]
-        - test -f $PREFIX/lib/libonedal_thread.so.1                # [linux]
-        - test -f $PREFIX/lib/libonedal.1.dylib                    # [osx]
-        - test -f $PREFIX/lib/libonedal_core.1.dylib               # [osx]
-        - test -f $PREFIX/lib/libonedal_thread.1.dylib             # [osx]
-        - IF NOT EXIST %PREFIX%\Library\bin\onedal*.dll EXIT /B 1  # [win]
-    about:
-      home: https://software.intel.com/content/www/us/en/develop/tools.html
-      summary: Intel® oneDAL runtime libraries
-      description: |
-        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
-        optimized building blocks covering all stages of data analytics: data acquisition from a data
-        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
-        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
-      license: Intel Simplified Software License
-      license_family: Proprietary
-      license_file:
-        - dal/info/licenses/license.txt
-        - dal/info/licenses/tpp.txt
-      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
-      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-      dev_url: https://github.com/oneapi-src/oneDAL
+  # - name: dal
+  #   version: {{ dal_version }}
+  #   script: repack.sh   # [unix]
+  #   script: repack.bat  # [win]
+  #   build:
+  #     number: {{ dal_buildnum }}
+  #     binary_relocation: false
+  #     detect_binary_files_with_prefix: false
+  #     missing_dso_whitelist:
+  #       # tbb: Since tbb version is wildcarded in run, so we need to call it out here:
+  #       - "$RPATH/libtbb.so.12"           # [linux]
+  #       - "$RPATH/libtbbmalloc.so.2"      # [linux]
+  #       # Optional intel-cmplr-lib-rt.
+  #       - "$RPATH/libimf.so"              # [linux]
+  #       - "$RPATH/libintlc.so.5"          # [linux]
+  #       - "$RPATH/libirng.so"             # [linux]
+  #       - "$RPATH/libsvml.so"             # [linux]
+  #       - "$RPATH/libmmd.dll"             # [win]
+  #       # Optional `intel-opencl-rt`:
+  #       - "$RPATH/libOpenCL.so.1"         # [linux]
+  #       - "$RPATH/OpenCL.dll"             # [win]
+  #       # # this comes from Intel's optional dpcpp_cpp_rt
+  #       - "$RPATH/libsycl.so.6"           # [linux]
+  #       # these two really shouldn't be here.  See mkl_repack_and_patchelf.sh
+  #       - libiomp5.so
+  #       - libcoi_device.so.0
+  #       # hooray, windows
+  #       - "C:\\Windows\\System32\\WINTRUST.dll" # [win]
+  #       # optional dpcpp runtime that we do not yet provide.
+  #       - "$RPATH/sycl6.dll"              # [win]
+  #       - "$RPATH/svml_dispmd.dll"        # [win]
+  #   requirements:
+  #     build:
+  #       - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
+  #     host:
+  #       - tbb {{ tbb_version.split('.')[0] }}.*
+  #     run:
+  #       - tbb {{ tbb_version.split('.')[0] }}.*
+  #   test:
+  #     commands:
+  #       - test -f $PREFIX/lib/libonedal.so.1                       # [linux]
+  #       - test -f $PREFIX/lib/libonedal_core.so.1                  # [linux]
+  #       - test -f $PREFIX/lib/libonedal_dpc.so.1                   # [linux]
+  #       - test -f $PREFIX/lib/libonedal_thread.so.1                # [linux]
+  #       - test -f $PREFIX/lib/libonedal.1.dylib                    # [osx]
+  #       - test -f $PREFIX/lib/libonedal_core.1.dylib               # [osx]
+  #       - test -f $PREFIX/lib/libonedal_thread.1.dylib             # [osx]
+  #       - IF NOT EXIST %PREFIX%\Library\bin\onedal*.dll EXIT /B 1  # [win]
+  #   about:
+  #     home: https://software.intel.com/content/www/us/en/develop/tools.html
+  #     summary: Intel® oneDAL runtime libraries
+  #     description: |
+  #       Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+  #       optimized building blocks covering all stages of data analytics: data acquisition from a data
+  #       source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+  #       This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
+  #     license: Intel Simplified Software License
+  #     license_family: Proprietary
+  #     license_file:
+  #       - dal/info/licenses/license.txt
+  #       - dal/info/licenses/tpp.txt
+  #     license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+  #     doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+  #     dev_url: https://github.com/oneapi-src/oneDAL
 
-  - name: dal-include
-    version: {{ dal_version }}
-    script: repack.sh   # [unix]
-    script: repack.bat  # [win]
-    build:
-      number: {{ dal_buildnum }}
-    # An empty requirements/build to satisfy anaconda-linter.
-    requirements:
-      build:
-    test:
-      commands:
-        - test -f $PREFIX/include/daal.h                   # [unix]
-        - test -f $PREFIX/include/daal_sycl.h              # [unix]
-        - IF NOT EXIST %PREFIX%\include\daal*.h EXIT /B 1  # [win]
-    about:
-      home: https://software.intel.com/content/www/us/en/develop/tools.html
-      summary: Headers for building against Intel® oneDAL libraries
-      description: |
-        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
-        optimized building blocks covering all stages of data analytics: data acquisition from a data
-        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
-        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
-      license: Intel Simplified Software License
-      license_family: Proprietary
-      license_file:
-        - dal-include/info/licenses/license.txt
-        - dal-include/info/licenses/tpp.txt
-      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
-      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-      dev_url: https://github.com/oneapi-src/oneDAL
+  # - name: dal-include
+  #   version: {{ dal_version }}
+  #   script: repack.sh   # [unix]
+  #   script: repack.bat  # [win]
+  #   build:
+  #     number: {{ dal_buildnum }}
+  #   # An empty requirements/build to satisfy anaconda-linter.
+  #   requirements:
+  #     build:
+  #   test:
+  #     commands:
+  #       - test -f $PREFIX/include/daal.h                   # [unix]
+  #       - test -f $PREFIX/include/daal_sycl.h              # [unix]
+  #       - IF NOT EXIST %PREFIX%\include\daal*.h EXIT /B 1  # [win]
+  #   about:
+  #     home: https://software.intel.com/content/www/us/en/develop/tools.html
+  #     summary: Headers for building against Intel® oneDAL libraries
+  #     description: |
+  #       Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+  #       optimized building blocks covering all stages of data analytics: data acquisition from a data
+  #       source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+  #       This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
+  #     license: Intel Simplified Software License
+  #     license_family: Proprietary
+  #     license_file:
+  #       - dal-include/info/licenses/license.txt
+  #       - dal-include/info/licenses/tpp.txt
+  #     license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+  #     doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+  #     dev_url: https://github.com/oneapi-src/oneDAL
 
-  - name: dal-static
-    version: {{ dal_version }}
-    script: repack.sh   # [unix]
-    script: repack.bat  # [win]
-    build:
-      number: {{ dal_buildnum }}
-      missing_dso_whitelist:
-        - $RPATH/sycld.dll            # [win]
-        - $RPATH/libmmdd.dll          # [win]
-        - "*\\tbb12.dll"              # [win]
-        - "*\\tbbmalloc.dll"          # [win]
-        - $RPATH/tbb12_debug.dll      # [win]
-        - $RPATH/tbbmalloc_debug.dll  # [win]
-        - $RPATH/svml_dispmd.dll      # [win]
-    requirements:
-      build:
-        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
-      run:
-        - {{ pin_subpackage('dal-include', exact=True) }}
-        - tbb {{ tbb_version.split('.')[0] }}.*
-    test:
-      commands:
-        - test -f $PREFIX/lib/libonedal.a                          # [unix]
-        - test -f $PREFIX/lib/libonedal_core.a                     # [unix]
-        - test -f $PREFIX/lib/libonedal_dpc.a                      # [linux]
-        - test -f $PREFIX/lib/libonedal_thread.a                   # [unix]
-        - test -f $PREFIX/lib/libdaal_thread.a                     # [unix]
-        - test -f $PREFIX/lib/libdaal_core.a                       # [unix]
-        - IF NOT EXIST %PREFIX%\Library\lib\onedal*.lib EXIT /B 1  # [win]
-    about:
-      home: https://software.intel.com/content/www/us/en/develop/tools.html
-      summary: Static libraries for Intel® oneDAL
-      description: |
-        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
-        optimized building blocks covering all stages of data analytics: data acquisition from a data
-        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
-        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
-      license: Intel Simplified Software License
-      license_family: Proprietary
-      license_file:
-        - dal-static/info/licenses/license.txt
-        - dal-static/info/licenses/tpp.txt
-      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
-      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-      dev_url: https://github.com/oneapi-src/oneDAL
+  # - name: dal-static
+  #   version: {{ dal_version }}
+  #   script: repack.sh   # [unix]
+  #   script: repack.bat  # [win]
+  #   build:
+  #     number: {{ dal_buildnum }}
+  #     missing_dso_whitelist:
+  #       - $RPATH/sycld.dll            # [win]
+  #       - $RPATH/libmmdd.dll          # [win]
+  #       - "*\\tbb12.dll"              # [win]
+  #       - "*\\tbbmalloc.dll"          # [win]
+  #       - $RPATH/tbb12_debug.dll      # [win]
+  #       - $RPATH/tbbmalloc_debug.dll  # [win]
+  #       - $RPATH/svml_dispmd.dll      # [win]
+  #   requirements:
+  #     build:
+  #       - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
+  #     run:
+  #       - {{ pin_subpackage('dal-include', exact=True) }}
+  #       - tbb {{ tbb_version.split('.')[0] }}.*
+  #   test:
+  #     commands:
+  #       - test -f $PREFIX/lib/libonedal.a                          # [unix]
+  #       - test -f $PREFIX/lib/libonedal_core.a                     # [unix]
+  #       - test -f $PREFIX/lib/libonedal_dpc.a                      # [linux]
+  #       - test -f $PREFIX/lib/libonedal_thread.a                   # [unix]
+  #       - test -f $PREFIX/lib/libdaal_thread.a                     # [unix]
+  #       - test -f $PREFIX/lib/libdaal_core.a                       # [unix]
+  #       - IF NOT EXIST %PREFIX%\Library\lib\onedal*.lib EXIT /B 1  # [win]
+  #   about:
+  #     home: https://software.intel.com/content/www/us/en/develop/tools.html
+  #     summary: Static libraries for Intel® oneDAL
+  #     description: |
+  #       Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+  #       optimized building blocks covering all stages of data analytics: data acquisition from a data
+  #       source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+  #       This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
+  #     license: Intel Simplified Software License
+  #     license_family: Proprietary
+  #     license_file:
+  #       - dal-static/info/licenses/license.txt
+  #       - dal-static/info/licenses/tpp.txt
+  #     license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+  #     doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+  #     dev_url: https://github.com/oneapi-src/oneDAL
 
-  - name: dal-devel
-    version: {{ dal_version }}
-    script: repack.sh   # [unix]
-    script: repack.bat  # [win]
-    build:
-      number: {{ dal_buildnum }}
-      run_exports:
-        - {{ pin_subpackage('dal') }}
-    requirements:
-      build:
-        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
-      run:
-        - {{ pin_subpackage('dal-include', exact=True) }}
-        - {{ pin_subpackage('dal', exact=True) }}
-    test:
-      commands:
-        - test -f $PREFIX/lib/libonedal_sycl.a                     # [linux]
-        # 2023/4/13: 2023.1.0-intel_43558 dooes not provide SYCL support for osx-64, see https://anaconda.org/intel/dal-devel/files?version=2023.1.1
-        - IF NOT EXIST %PREFIX%\Library\lib\onedal*.lib EXIT /B 1  # [win]
-    about:
-      home: https://software.intel.com/content/www/us/en/develop/tools.html
-      summary: Devel package for building things linked against Intel® oneDAL shared libraries
-      description: |
-        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
-        optimized building blocks covering all stages of data analytics: data acquisition from a data
-        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
-        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
-      license: Intel Simplified Software License
-      license_family: Proprietary
-      # 2023/4/13: An error on osx-64:
-      # ValueError: License file given in about/license_file ([...]recipe/dal-devel/info/licenses/license.txt) does not exist in source root dir or in recipe root dir (with meta.yaml)
-      #license_file:
-      #  - dal-devel/info/licenses/license.txt
-      #  - dal-devel/info/licenses/tpp.txt
-      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
-      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-      dev_url: https://github.com/oneapi-src/oneDAL
+  # - name: dal-devel
+  #   version: {{ dal_version }}
+  #   script: repack.sh   # [unix]
+  #   script: repack.bat  # [win]
+  #   build:
+  #     number: {{ dal_buildnum }}
+  #     run_exports:
+  #       - {{ pin_subpackage('dal') }}
+  #   requirements:
+  #     build:
+  #       - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
+  #     run:
+  #       - {{ pin_subpackage('dal-include', exact=True) }}
+  #       - {{ pin_subpackage('dal', exact=True) }}
+  #   test:
+  #     commands:
+  #       - test -f $PREFIX/lib/libonedal_sycl.a                     # [linux]
+  #       # 2023/4/13: 2023.1.0-intel_43558 dooes not provide SYCL support for osx-64, see https://anaconda.org/intel/dal-devel/files?version=2023.1.1
+  #       - IF NOT EXIST %PREFIX%\Library\lib\onedal*.lib EXIT /B 1  # [win]
+  #   about:
+  #     home: https://software.intel.com/content/www/us/en/develop/tools.html
+  #     summary: Devel package for building things linked against Intel® oneDAL shared libraries
+  #     description: |
+  #       Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+  #       optimized building blocks covering all stages of data analytics: data acquisition from a data
+  #       source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+  #       This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
+  #     license: Intel Simplified Software License
+  #     license_family: Proprietary
+  #     # 2023/4/13: An error on osx-64:
+  #     # ValueError: License file given in about/license_file ([...]recipe/dal-devel/info/licenses/license.txt) does not exist in source root dir or in recipe root dir (with meta.yaml)
+  #     #license_file:
+  #     #  - dal-devel/info/licenses/license.txt
+  #     #  - dal-devel/info/licenses/tpp.txt
+  #     license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+  #     doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+  #     dev_url: https://github.com/oneapi-src/oneDAL
 
 # Satisfy the linter
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@
 
 
 # Bump all build numbers here. (Note: it may be appropriate to use selectors here.)
-{% set bump_all_buildnum = "0" %}
+{% set bump_all_buildnum = "1" %}
 # Bump specific package build numbers here. (Note: it may be appropriate to use selectors here.)
 {% set bump_mkl_buildnum = "1" %}
 {% set bump_openmp_buildnum = "0" %}
@@ -267,10 +267,11 @@ outputs:
         - __glibc >=2.17                  # [linux] - intel-openmp 2021.1.1 and newer is built with a newer GLIBC
     test:
       commands:
-        - test -f $PREFIX/lib/libiomp5${SHLIB_EXT}                  # [unix]
-        - test -f $PREFIX/lib/libomptarget${SHLIB_EXT}              # [linux]
-        - IF NOT EXIST %PREFIX%\Library\bin\libiomp*.dll EXIT /B 1  # [win]
-        - IF NOT EXIST %PREFIX%\Library\bin\omp*.dll EXIT /B 1      # [win]
+        - test -f $PREFIX/lib/libiomp5${SHLIB_EXT}                        # [unix]
+        - test -f $PREFIX/lib/libomptarget${SHLIB_EXT}                    # [linux]
+        - IF NOT EXIST %PREFIX%\Library\bin\libiomp*.dll EXIT /B 1        # [win]
+        - IF NOT EXIST %PREFIX%\Library\bin\omp*.dll EXIT /B 1            # [win]
+        - IF NOT EXIST %PREFIX%\Library\lib\libiomp5md_dll.lib echo "%PREFIX%\Library\lib\libiomp5md_dll.lib is missing" & EXIT /B 1  # [win]
     about:
       home: https://software.intel.com/en-us/node/522690
       license: LicenseRef-ProprietaryIntel

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -102,18 +102,18 @@ source:
   - url: https://anaconda.org/intel/intel-openmp/{{ openmp_version }}/download/{{ target_platform }}/intel-openmp-{{ openmp_version }}-intel_{{ openmp_fetch_buildnum }}.tar.bz2
     folder: intel-openmp
     sha256: {{ intel_openmp_hash }}
-  # - url: https://anaconda.org/intel/dal/{{ dal_version }}/download/{{ target_platform }}/dal-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
-  #   folder: dal
-  #   sha256: {{ dal_hash }}
-  # - url: https://anaconda.org/intel/dal-include/{{ dal_version }}/download/{{ target_platform }}/dal-include-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
-  #   folder: dal-include
-  #   sha256: {{ dal_include_hash }}
-  # - url: https://anaconda.org/intel/dal-static/{{ dal_version }}/download/{{ target_platform }}/dal-static-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
-  #   folder: dal-static
-  #   sha256: {{ dal_static_hash }}
-  # - url: https://anaconda.org/intel/dal-devel/{{ dal_version }}/download/{{ target_platform }}/dal-devel-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
-  #   folder: dal-devel
-  #   sha256: {{ dal_devel_hash }}
+  - url: https://anaconda.org/intel/dal/{{ dal_version }}/download/{{ target_platform }}/dal-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
+    folder: dal
+    sha256: {{ dal_hash }}
+  - url: https://anaconda.org/intel/dal-include/{{ dal_version }}/download/{{ target_platform }}/dal-include-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
+    folder: dal-include
+    sha256: {{ dal_include_hash }}
+  - url: https://anaconda.org/intel/dal-static/{{ dal_version }}/download/{{ target_platform }}/dal-static-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
+    folder: dal-static
+    sha256: {{ dal_static_hash }}
+  - url: https://anaconda.org/intel/dal-devel/{{ dal_version }}/download/{{ target_platform }}/dal-devel-{{ dal_version }}-intel_{{ dal_fetch_buildnum }}.tar.bz2
+    folder: dal-devel
+    sha256: {{ dal_devel_hash }}
 
 build:
   number: {{ mkl_buildnum }}
@@ -316,185 +316,185 @@ outputs:
       license_file: ANACONDA_LICENSE
       summary: 'BLAS mutex for MKL'
 
-  # - name: dal
-  #   version: {{ dal_version }}
-  #   script: repack.sh   # [unix]
-  #   script: repack.bat  # [win]
-  #   build:
-  #     number: {{ dal_buildnum }}
-  #     binary_relocation: false
-  #     detect_binary_files_with_prefix: false
-  #     missing_dso_whitelist:
-  #       # tbb: Since tbb version is wildcarded in run, so we need to call it out here:
-  #       - "$RPATH/libtbb.so.12"           # [linux]
-  #       - "$RPATH/libtbbmalloc.so.2"      # [linux]
-  #       # Optional intel-cmplr-lib-rt.
-  #       - "$RPATH/libimf.so"              # [linux]
-  #       - "$RPATH/libintlc.so.5"          # [linux]
-  #       - "$RPATH/libirng.so"             # [linux]
-  #       - "$RPATH/libsvml.so"             # [linux]
-  #       - "$RPATH/libmmd.dll"             # [win]
-  #       # Optional `intel-opencl-rt`:
-  #       - "$RPATH/libOpenCL.so.1"         # [linux]
-  #       - "$RPATH/OpenCL.dll"             # [win]
-  #       # # this comes from Intel's optional dpcpp_cpp_rt
-  #       - "$RPATH/libsycl.so.6"           # [linux]
-  #       # these two really shouldn't be here.  See mkl_repack_and_patchelf.sh
-  #       - libiomp5.so
-  #       - libcoi_device.so.0
-  #       # hooray, windows
-  #       - "C:\\Windows\\System32\\WINTRUST.dll" # [win]
-  #       # optional dpcpp runtime that we do not yet provide.
-  #       - "$RPATH/sycl6.dll"              # [win]
-  #       - "$RPATH/svml_dispmd.dll"        # [win]
-  #   requirements:
-  #     build:
-  #       - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
-  #     host:
-  #       - tbb {{ tbb_version.split('.')[0] }}.*
-  #     run:
-  #       - tbb {{ tbb_version.split('.')[0] }}.*
-  #   test:
-  #     commands:
-  #       - test -f $PREFIX/lib/libonedal.so.1                       # [linux]
-  #       - test -f $PREFIX/lib/libonedal_core.so.1                  # [linux]
-  #       - test -f $PREFIX/lib/libonedal_dpc.so.1                   # [linux]
-  #       - test -f $PREFIX/lib/libonedal_thread.so.1                # [linux]
-  #       - test -f $PREFIX/lib/libonedal.1.dylib                    # [osx]
-  #       - test -f $PREFIX/lib/libonedal_core.1.dylib               # [osx]
-  #       - test -f $PREFIX/lib/libonedal_thread.1.dylib             # [osx]
-  #       - IF NOT EXIST %PREFIX%\Library\bin\onedal*.dll EXIT /B 1  # [win]
-  #   about:
-  #     home: https://software.intel.com/content/www/us/en/develop/tools.html
-  #     summary: Intel® oneDAL runtime libraries
-  #     description: |
-  #       Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
-  #       optimized building blocks covering all stages of data analytics: data acquisition from a data
-  #       source, preprocessing, transformation, data mining, modeling, validation, and decision making.
-  #       This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
-  #     license: Intel Simplified Software License
-  #     license_family: Proprietary
-  #     license_file:
-  #       - dal/info/licenses/license.txt
-  #       - dal/info/licenses/tpp.txt
-  #     license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
-  #     doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-  #     dev_url: https://github.com/oneapi-src/oneDAL
+  - name: dal
+    version: {{ dal_version }}
+    script: repack.sh   # [unix]
+    script: repack.bat  # [win]
+    build:
+      number: {{ dal_buildnum }}
+      binary_relocation: false
+      detect_binary_files_with_prefix: false
+      missing_dso_whitelist:
+        # tbb: Since tbb version is wildcarded in run, so we need to call it out here:
+        - "$RPATH/libtbb.so.12"           # [linux]
+        - "$RPATH/libtbbmalloc.so.2"      # [linux]
+        # Optional intel-cmplr-lib-rt.
+        - "$RPATH/libimf.so"              # [linux]
+        - "$RPATH/libintlc.so.5"          # [linux]
+        - "$RPATH/libirng.so"             # [linux]
+        - "$RPATH/libsvml.so"             # [linux]
+        - "$RPATH/libmmd.dll"             # [win]
+        # Optional `intel-opencl-rt`:
+        - "$RPATH/libOpenCL.so.1"         # [linux]
+        - "$RPATH/OpenCL.dll"             # [win]
+        # # this comes from Intel's optional dpcpp_cpp_rt
+        - "$RPATH/libsycl.so.6"           # [linux]
+        # these two really shouldn't be here.  See mkl_repack_and_patchelf.sh
+        - libiomp5.so
+        - libcoi_device.so.0
+        # hooray, windows
+        - "C:\\Windows\\System32\\WINTRUST.dll" # [win]
+        # optional dpcpp runtime that we do not yet provide.
+        - "$RPATH/sycl6.dll"              # [win]
+        - "$RPATH/svml_dispmd.dll"        # [win]
+    requirements:
+      build:
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
+      host:
+        - tbb {{ tbb_version.split('.')[0] }}.*
+      run:
+        - tbb {{ tbb_version.split('.')[0] }}.*
+    test:
+      commands:
+        - test -f $PREFIX/lib/libonedal.so.1                       # [linux]
+        - test -f $PREFIX/lib/libonedal_core.so.1                  # [linux]
+        - test -f $PREFIX/lib/libonedal_dpc.so.1                   # [linux]
+        - test -f $PREFIX/lib/libonedal_thread.so.1                # [linux]
+        - test -f $PREFIX/lib/libonedal.1.dylib                    # [osx]
+        - test -f $PREFIX/lib/libonedal_core.1.dylib               # [osx]
+        - test -f $PREFIX/lib/libonedal_thread.1.dylib             # [osx]
+        - IF NOT EXIST %PREFIX%\Library\bin\onedal*.dll EXIT /B 1  # [win]
+    about:
+      home: https://software.intel.com/content/www/us/en/develop/tools.html
+      summary: Intel® oneDAL runtime libraries
+      description: |
+        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+        optimized building blocks covering all stages of data analytics: data acquisition from a data
+        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
+      license: Intel Simplified Software License
+      license_family: Proprietary
+      license_file:
+        - dal/info/licenses/license.txt
+        - dal/info/licenses/tpp.txt
+      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://github.com/oneapi-src/oneDAL
 
-  # - name: dal-include
-  #   version: {{ dal_version }}
-  #   script: repack.sh   # [unix]
-  #   script: repack.bat  # [win]
-  #   build:
-  #     number: {{ dal_buildnum }}
-  #   # An empty requirements/build to satisfy anaconda-linter.
-  #   requirements:
-  #     build:
-  #   test:
-  #     commands:
-  #       - test -f $PREFIX/include/daal.h                   # [unix]
-  #       - test -f $PREFIX/include/daal_sycl.h              # [unix]
-  #       - IF NOT EXIST %PREFIX%\include\daal*.h EXIT /B 1  # [win]
-  #   about:
-  #     home: https://software.intel.com/content/www/us/en/develop/tools.html
-  #     summary: Headers for building against Intel® oneDAL libraries
-  #     description: |
-  #       Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
-  #       optimized building blocks covering all stages of data analytics: data acquisition from a data
-  #       source, preprocessing, transformation, data mining, modeling, validation, and decision making.
-  #       This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
-  #     license: Intel Simplified Software License
-  #     license_family: Proprietary
-  #     license_file:
-  #       - dal-include/info/licenses/license.txt
-  #       - dal-include/info/licenses/tpp.txt
-  #     license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
-  #     doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-  #     dev_url: https://github.com/oneapi-src/oneDAL
+  - name: dal-include
+    version: {{ dal_version }}
+    script: repack.sh   # [unix]
+    script: repack.bat  # [win]
+    build:
+      number: {{ dal_buildnum }}
+    # An empty requirements/build to satisfy anaconda-linter.
+    requirements:
+      build:
+    test:
+      commands:
+        - test -f $PREFIX/include/daal.h                   # [unix]
+        - test -f $PREFIX/include/daal_sycl.h              # [unix]
+        - IF NOT EXIST %PREFIX%\include\daal*.h EXIT /B 1  # [win]
+    about:
+      home: https://software.intel.com/content/www/us/en/develop/tools.html
+      summary: Headers for building against Intel® oneDAL libraries
+      description: |
+        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+        optimized building blocks covering all stages of data analytics: data acquisition from a data
+        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
+      license: Intel Simplified Software License
+      license_family: Proprietary
+      license_file:
+        - dal-include/info/licenses/license.txt
+        - dal-include/info/licenses/tpp.txt
+      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://github.com/oneapi-src/oneDAL
 
-  # - name: dal-static
-  #   version: {{ dal_version }}
-  #   script: repack.sh   # [unix]
-  #   script: repack.bat  # [win]
-  #   build:
-  #     number: {{ dal_buildnum }}
-  #     missing_dso_whitelist:
-  #       - $RPATH/sycld.dll            # [win]
-  #       - $RPATH/libmmdd.dll          # [win]
-  #       - "*\\tbb12.dll"              # [win]
-  #       - "*\\tbbmalloc.dll"          # [win]
-  #       - $RPATH/tbb12_debug.dll      # [win]
-  #       - $RPATH/tbbmalloc_debug.dll  # [win]
-  #       - $RPATH/svml_dispmd.dll      # [win]
-  #   requirements:
-  #     build:
-  #       - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
-  #     run:
-  #       - {{ pin_subpackage('dal-include', exact=True) }}
-  #       - tbb {{ tbb_version.split('.')[0] }}.*
-  #   test:
-  #     commands:
-  #       - test -f $PREFIX/lib/libonedal.a                          # [unix]
-  #       - test -f $PREFIX/lib/libonedal_core.a                     # [unix]
-  #       - test -f $PREFIX/lib/libonedal_dpc.a                      # [linux]
-  #       - test -f $PREFIX/lib/libonedal_thread.a                   # [unix]
-  #       - test -f $PREFIX/lib/libdaal_thread.a                     # [unix]
-  #       - test -f $PREFIX/lib/libdaal_core.a                       # [unix]
-  #       - IF NOT EXIST %PREFIX%\Library\lib\onedal*.lib EXIT /B 1  # [win]
-  #   about:
-  #     home: https://software.intel.com/content/www/us/en/develop/tools.html
-  #     summary: Static libraries for Intel® oneDAL
-  #     description: |
-  #       Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
-  #       optimized building blocks covering all stages of data analytics: data acquisition from a data
-  #       source, preprocessing, transformation, data mining, modeling, validation, and decision making.
-  #       This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
-  #     license: Intel Simplified Software License
-  #     license_family: Proprietary
-  #     license_file:
-  #       - dal-static/info/licenses/license.txt
-  #       - dal-static/info/licenses/tpp.txt
-  #     license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
-  #     doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-  #     dev_url: https://github.com/oneapi-src/oneDAL
+  - name: dal-static
+    version: {{ dal_version }}
+    script: repack.sh   # [unix]
+    script: repack.bat  # [win]
+    build:
+      number: {{ dal_buildnum }}
+      missing_dso_whitelist:
+        - $RPATH/sycld.dll            # [win]
+        - $RPATH/libmmdd.dll          # [win]
+        - "*\\tbb12.dll"              # [win]
+        - "*\\tbbmalloc.dll"          # [win]
+        - $RPATH/tbb12_debug.dll      # [win]
+        - $RPATH/tbbmalloc_debug.dll  # [win]
+        - $RPATH/svml_dispmd.dll      # [win]
+    requirements:
+      build:
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
+      run:
+        - {{ pin_subpackage('dal-include', exact=True) }}
+        - tbb {{ tbb_version.split('.')[0] }}.*
+    test:
+      commands:
+        - test -f $PREFIX/lib/libonedal.a                          # [unix]
+        - test -f $PREFIX/lib/libonedal_core.a                     # [unix]
+        - test -f $PREFIX/lib/libonedal_dpc.a                      # [linux]
+        - test -f $PREFIX/lib/libonedal_thread.a                   # [unix]
+        - test -f $PREFIX/lib/libdaal_thread.a                     # [unix]
+        - test -f $PREFIX/lib/libdaal_core.a                       # [unix]
+        - IF NOT EXIST %PREFIX%\Library\lib\onedal*.lib EXIT /B 1  # [win]
+    about:
+      home: https://software.intel.com/content/www/us/en/develop/tools.html
+      summary: Static libraries for Intel® oneDAL
+      description: |
+        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+        optimized building blocks covering all stages of data analytics: data acquisition from a data
+        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
+      license: Intel Simplified Software License
+      license_family: Proprietary
+      license_file:
+        - dal-static/info/licenses/license.txt
+        - dal-static/info/licenses/tpp.txt
+      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://github.com/oneapi-src/oneDAL
 
-  # - name: dal-devel
-  #   version: {{ dal_version }}
-  #   script: repack.sh   # [unix]
-  #   script: repack.bat  # [win]
-  #   build:
-  #     number: {{ dal_buildnum }}
-  #     run_exports:
-  #       - {{ pin_subpackage('dal') }}
-  #   requirements:
-  #     build:
-  #       - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
-  #     run:
-  #       - {{ pin_subpackage('dal-include', exact=True) }}
-  #       - {{ pin_subpackage('dal', exact=True) }}
-  #   test:
-  #     commands:
-  #       - test -f $PREFIX/lib/libonedal_sycl.a                     # [linux]
-  #       # 2023/4/13: 2023.1.0-intel_43558 dooes not provide SYCL support for osx-64, see https://anaconda.org/intel/dal-devel/files?version=2023.1.1
-  #       - IF NOT EXIST %PREFIX%\Library\lib\onedal*.lib EXIT /B 1  # [win]
-  #   about:
-  #     home: https://software.intel.com/content/www/us/en/develop/tools.html
-  #     summary: Devel package for building things linked against Intel® oneDAL shared libraries
-  #     description: |
-  #       Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
-  #       optimized building blocks covering all stages of data analytics: data acquisition from a data
-  #       source, preprocessing, transformation, data mining, modeling, validation, and decision making.
-  #       This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
-  #     license: Intel Simplified Software License
-  #     license_family: Proprietary
-  #     # 2023/4/13: An error on osx-64:
-  #     # ValueError: License file given in about/license_file ([...]recipe/dal-devel/info/licenses/license.txt) does not exist in source root dir or in recipe root dir (with meta.yaml)
-  #     #license_file:
-  #     #  - dal-devel/info/licenses/license.txt
-  #     #  - dal-devel/info/licenses/tpp.txt
-  #     license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
-  #     doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
-  #     dev_url: https://github.com/oneapi-src/oneDAL
+  - name: dal-devel
+    version: {{ dal_version }}
+    script: repack.sh   # [unix]
+    script: repack.bat  # [win]
+    build:
+      number: {{ dal_buildnum }}
+      run_exports:
+        - {{ pin_subpackage('dal') }}
+    requirements:
+      build:
+        - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.
+      run:
+        - {{ pin_subpackage('dal-include', exact=True) }}
+        - {{ pin_subpackage('dal', exact=True) }}
+    test:
+      commands:
+        - test -f $PREFIX/lib/libonedal_sycl.a                     # [linux]
+        # 2023/4/13: 2023.1.0-intel_43558 dooes not provide SYCL support for osx-64, see https://anaconda.org/intel/dal-devel/files?version=2023.1.1
+        - IF NOT EXIST %PREFIX%\Library\lib\onedal*.lib EXIT /B 1  # [win]
+    about:
+      home: https://software.intel.com/content/www/us/en/develop/tools.html
+      summary: Devel package for building things linked against Intel® oneDAL shared libraries
+      description: |
+        Intel® Data Analytics Acceleration Library (Intel® oneDAL) is the library of Intel® architecture
+        optimized building blocks covering all stages of data analytics: data acquisition from a data
+        source, preprocessing, transformation, data mining, modeling, validation, and decision making.
+        This package is a repackaged set of binaries obtained directly from Intel\'s anaconda.org channel.
+      license: Intel Simplified Software License
+      license_family: Proprietary
+      # 2023/4/13: An error on osx-64:
+      # ValueError: License file given in about/license_file ([...]recipe/dal-devel/info/licenses/license.txt) does not exist in source root dir or in recipe root dir (with meta.yaml)
+      #license_file:
+      #  - dal-devel/info/licenses/license.txt
+      #  - dal-devel/info/licenses/tpp.txt
+      license_url: https://software.intel.com/content/www/us/en/develop/articles/end-user-license-agreement.html
+      doc_url: https://software.intel.com/content/www/us/en/develop/tools.html
+      dev_url: https://github.com/oneapi-src/oneDAL
 
 # Satisfy the linter
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -233,8 +233,8 @@ outputs:
         - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
         - cmake -S tests/mkl-devel -B build -G Ninja -DCMAKE_VERBOSE_MAKEFILE=ON
         - cmake --build build -v
-        - cd build && ctest  # [not win]
-        - cd build\Debug && ctest  # [win]
+        - ./build/myapp  # [not win]
+        - .\build\Debug\myapp  # [win]
     about:
       home: https://software.intel.com/en-us/mkl
       summary: Metapackage of MKL headers and libraries for developing software that uses MKL

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -94,6 +94,8 @@ source:
   - url: https://anaconda.org/intel/mkl-devel/{{ mkl_version }}/download/{{ target_platform }}/mkl-devel-{{ mkl_version }}-intel_{{ mkl_fetch_buildnum }}.tar.bz2
     folder: mkl-devel
     sha256: {{ mkl_devel_hash }}
+    patches:                                  # [win]
+      - patches/0001-MKLConfig-windows.patch  # [win]
   - url: https://anaconda.org/intel/mkl-include/{{ mkl_version }}/download/{{ target_platform }}/mkl-include-{{ mkl_version }}-intel_{{ mkl_fetch_buildnum }}.tar.bz2
     folder: mkl-include
     sha256: {{ mkl_include_hash }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -228,6 +228,8 @@ outputs:
         - cmake
         - ninja
         - pkg-config
+        # This is to get the omp.h header.
+        - llvm-openmp  # [osx]
       files:
         - tests
       commands:
@@ -235,10 +237,10 @@ outputs:
         # Verify that the mkl library can be located through pkg-config
         - test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/libmkl_rt${SHLIB_EXT}  # [unix]
         - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
-        - cmake -S tests/mkl-devel -B build -G Ninja -DCMAKE_VERBOSE_MAKEFILE=ON  # [linux or win]
-        - cmake --build build -v                                                  # [linux or win]
-        - ./build/myapp                                                           # [linux]
-        - build\myapp                                                             # [win]
+        - cmake -S tests/mkl-devel -B build -G Ninja -DCMAKE_VERBOSE_MAKEFILE=ON
+        - cmake --build build -v
+        - ./build/myapp  # [not win]
+        - build\myapp    # [win]
     about:
       home: https://software.intel.com/en-us/mkl
       summary: Metapackage of MKL headers and libraries for developing software that uses MKL

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -217,13 +217,21 @@ outputs:
         - {{ pin_subpackage('mkl-include', exact=True) }}
         - blas * mkl
     test:
+      requires:
+        - {{ compiler('c') }}
+        - cmake
+        - ninja
+        - pkg-config
+      files:
+        - tests
       commands:
         - IF NOT EXIST %PREFIX%\Library\lib\mkl*dll.lib EXIT /B 1  # [win]
         # Verify that the mkl library can be located through pkg-config
         - test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/libmkl_rt${SHLIB_EXT}  # [unix]
         - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
-      requires:
-        - pkg-config
+        - cmake -S tests/mkl-devel -B build -G Ninja -DCMAKE_VERBOSE_MAKEFILE=ON
+        - cmake --build build
+        - cd build && ctest
     about:
       home: https://software.intel.com/en-us/mkl
       summary: Metapackage of MKL headers and libraries for developing software that uses MKL

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -123,6 +123,10 @@ build:
   runpath_whitelist:     # <---------------------------------------------------------------------------------------------------------------------------------   Do a trial remove
     - $ORIGIN
 
+requirements:
+  build:
+    - m2-patch  # [win]
+
 outputs:
   - name: mkl
     script: repack.sh   # [unix]
@@ -231,10 +235,10 @@ outputs:
         # Verify that the mkl library can be located through pkg-config
         - test -f `pkg-config --variable=libdir --dont-define-prefix mkl-sdl`/libmkl_rt${SHLIB_EXT}  # [unix]
         - for /f "usebackq tokens=*" %%a in (`pkg-config --variable=libdir --dont-define-prefix mkl-sdl`) do if not exist "%%a/mkl_rt.lib" exit 1  # [win]
-        - cmake -S tests/mkl-devel -B build -G Ninja -DCMAKE_VERBOSE_MAKEFILE=ON
-        - cmake --build build -v
-        - ./build/myapp  # [not win]
-        - .\build\Debug\myapp  # [win]
+        - cmake -S tests/mkl-devel -B build -G Ninja -DCMAKE_VERBOSE_MAKEFILE=ON  # [linux or win]
+        - cmake --build build -v                                                  # [linux or win]
+        - ./build/myapp                                                           # [linux]
+        - build\myapp                                                             # [win]
     about:
       home: https://software.intel.com/en-us/mkl
       summary: Metapackage of MKL headers and libraries for developing software that uses MKL
@@ -265,6 +269,7 @@ outputs:
         - "$RPATH/ze_loader.dll"          # [win]   - optional oneAPI Level Zero loader.
         # Optional dpcpp_cpp_rt
         - "$RPATH/libsycl.so.6"           # [linux]
+        - "$RPATH/sycl6.dll"              # [win]
     requirements:
       build:
         - {{ compiler('cxx') }}           # Compiler added for automatic inclusion of `missing_dso_whitelist` values.

--- a/recipe/patches/0001-MKLConfig-windows.patch
+++ b/recipe/patches/0001-MKLConfig-windows.patch
@@ -1,0 +1,31 @@
+From 9ecc2d7a195690956d358fda4d9e22f29c1a0f01 Mon Sep 17 00:00:00 2001
+From: Jean-Christophe Morin <jcmorin@anaconda.com>
+Date: Fri, 3 Nov 2023 13:48:23 -0400
+Subject: [PATCH] Fix MKLConfig to allow it to find libraries from conda packages.
+
+---
+ Library/lib/cmake/mkl/MKLConfig.cmake | 4 ++++++------
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Library/lib/cmake/mkl/MKLConfig.cmake b/Library/lib/cmake/mkl/MKLConfig.cmake
+index 9195b73b..cfd01c2d 100644
+--- a/Library/lib/cmake/mkl/MKLConfig.cmake
++++ b/Library/lib/cmake/mkl/MKLConfig.cmake
+@@ -632,7 +632,7 @@ foreach(lib ${MKL_LIBRARIES})
+     set_target_properties(MKL::${lib} PROPERTIES IMPORTED_IMPLIB "${${lib}_file}")
+     # Find corresponding DLL
+     set(MKL_DLL_GLOB ${lib}.*.dll)
+-    file(GLOB MKL_DLL_FILE "${MKL_ROOT}/redist/${MKL_ARCH}/${MKL_DLL_GLOB}"
++    file(GLOB MKL_DLL_FILE "${MKL_ROOT}/bin/${MKL_DLL_GLOB}"
+         "${MKL_ROOT}/../redist/${MKL_ARCH}/${MKL_DLL_GLOB}"
+         "${MKL_ROOT}/../redist/${MKL_ARCH}/mkl/${MKL_DLL_GLOB}")
+     if(NOT ${lib} STREQUAL ${MKL_IFACE_LIB} AND NOT ${lib} STREQUAL ${MKL_BLAS95} AND NOT ${lib} STREQUAL ${MKL_LAPACK95})  # Windows IFACE libs are static only
+@@ -719,7 +719,7 @@ if(MKL_THREADING)
+         set(OMP_DLLNAME ${LIB_PREFIX}${MKL_OMP_LIB}.dll)
+         find_path(OMP_DLL_DIR ${OMP_DLLNAME}
+           HINTS $ENV{LIB} $ENV{LIBRARY_PATH} $ENV{MKLROOT} ${MKL_ROOT} $ENV{CMPLR_ROOT}
+-          PATH_SUFFIXES "redist/${MKL_ARCH}"
++          PATH_SUFFIXES "bin"
+                "redist/${MKL_ARCH}_win" "redist/${MKL_ARCH}_win/compiler"
+                "../redist/${MKL_ARCH}/compiler" "../compiler/lib"
+                "../../compiler/latest/windows/redist/${MKL_ARCH}_win"

--- a/recipe/patches/0001-MKLConfig-windows.patch
+++ b/recipe/patches/0001-MKLConfig-windows.patch
@@ -1,14 +1,5 @@
-From 9ecc2d7a195690956d358fda4d9e22f29c1a0f01 Mon Sep 17 00:00:00 2001
-From: Jean-Christophe Morin <jcmorin@anaconda.com>
-Date: Fri, 3 Nov 2023 13:48:23 -0400
-Subject: [PATCH] Fix MKLConfig to allow it to find libraries from conda packages.
-
----
- Library/lib/cmake/mkl/MKLConfig.cmake | 4 ++++++------
- 1 file changed, 2 insertions(+), 2 deletions(-)
-
-diff --git a/Library/lib/cmake/mkl/MKLConfig.cmake b/Library/lib/cmake/mkl/MKLConfig.cmake
-index 9195b73b..cfd01c2d 100644
+﻿diff --git a/Library/lib/cmake/mkl/MKLConfig.cmake b/Library/lib/cmake/mkl/MKLConfig.cmake
+index ff1ffce..f80b551 100644
 --- a/Library/lib/cmake/mkl/MKLConfig.cmake
 +++ b/Library/lib/cmake/mkl/MKLConfig.cmake
 @@ -632,7 +632,7 @@ foreach(lib ${MKL_LIBRARIES})
@@ -29,3 +20,6 @@ index 9195b73b..cfd01c2d 100644
                 "redist/${MKL_ARCH}_win" "redist/${MKL_ARCH}_win/compiler"
                 "../redist/${MKL_ARCH}/compiler" "../compiler/lib"
                 "../../compiler/latest/windows/redist/${MKL_ARCH}_win"
+-- 
+2.42.0
+

--- a/recipe/repack.bat
+++ b/recipe/repack.bat
@@ -13,3 +13,19 @@ if %ERRORLEVEL% GEQ 8 exit 1
 
 :: replace old info folder with our new regenerated one
 rd /s /q %PREFIX%\info
+
+if "%PKG_NAME%"=="intel-openmp" (
+    echo "Generating libiomp5md_dll.lib"
+    :: If in the fiture Intel decies to ship the import library, error out.
+    :: If this happens, please remove this hack.
+    if exist %LIBRARY_PREFIX%\lib\libiomp5md_dll.lib exit 1
+
+    :: Create the import library for libiomp5md.dll. Intel unfortunately doesn't provide it.
+    cd %LIBRARY_PREFIX%\bin
+    %RECIPE_DIR%\dll2lib.bat 64 libiomp5md.dll
+    if %ERRORLEVEL% GEQ 1 exit 1
+
+    dir %LIBRARY_PREFIX%
+    dir %LIBRARY_PREFIX%\lib
+    if not exist %LIBRARY_PREFIX%\lib\libiomp5md_dll.lib exit 1
+)

--- a/recipe/repack.bat
+++ b/recipe/repack.bat
@@ -15,10 +15,10 @@ if %ERRORLEVEL% GEQ 8 exit 1
 rd /s /q %PREFIX%\info
 
 if "%PKG_NAME%"=="intel-openmp" (
-    echo "Generating libiomp5md_dll.lib"
+    echo "Generating libiomp5md.lib"
     :: If in the fiture Intel decies to ship the import library, error out.
     :: If this happens, please remove this hack.
-    if exist %LIBRARY_PREFIX%\lib\libiomp5md_dll.lib exit 1
+    if exist %LIBRARY_PREFIX%\lib\libiomp5md.lib exit 1
 
     :: Create the import library for libiomp5md.dll. Intel unfortunately doesn't provide it.
     cd %LIBRARY_PREFIX%\bin
@@ -27,5 +27,5 @@ if "%PKG_NAME%"=="intel-openmp" (
 
     dir %LIBRARY_PREFIX%
     dir %LIBRARY_PREFIX%\lib
-    if not exist %LIBRARY_PREFIX%\lib\libiomp5md_dll.lib exit 1
+    if not exist %LIBRARY_PREFIX%\lib\libiomp5md.lib exit 1
 )

--- a/recipe/repack.bat
+++ b/recipe/repack.bat
@@ -11,7 +11,7 @@ set "src=%SRC_DIR%\%PKG_NAME%"
 robocopy /E "%src%" "%PREFIX%"
 if %ERRORLEVEL% GEQ 8 exit 1
 
-:: replace old info folder with our new regenerated one
+:: Remove info coming from conda package. conda-build will provide its own metadata.
 rd /s /q %PREFIX%\info
 
 if "%PKG_NAME%"=="intel-openmp" (

--- a/recipe/repack.bat
+++ b/recipe/repack.bat
@@ -22,6 +22,9 @@ if "%PKG_NAME%"=="intel-openmp" (
 
     :: Create the import library for libiomp5md.dll. Intel unfortunately doesn't provide it.
     cd %LIBRARY_PREFIX%\bin
+    :: Note that both CMake's FindMKL and Pytorch's own FindMKL modules want and expect
+    :: "libiomp5md.dll", not "libiomp5md_dll.dll"!
+    :: The same can be said about the MKLConfig cmake file provided by mkl-devel.
     %RECIPE_DIR%\dll2lib.bat 64 libiomp5md.dll
     if %ERRORLEVEL% GEQ 1 exit 1
 

--- a/recipe/repack.sh
+++ b/recipe/repack.sh
@@ -15,5 +15,5 @@ src="$SRC_DIR/$PKG_NAME"
 
 cp -rv "$src"/* "$PREFIX/"
 
-# replace old info folder with our new regenerated one
-rm -rf "$PREFIX/info"
+# Remove info coming from conda package. conda-build will provide its own metadata.
+rm -rvf "$PREFIX/info"

--- a/recipe/tests/mkl-devel/CMakeLists.txt
+++ b/recipe/tests/mkl-devel/CMakeLists.txt
@@ -4,6 +4,8 @@ enable_testing()
 
 project(mkl_example LANGUAGES C)
 
+set(MKL_THREADING "intel_thread")
+
 find_package(MKL CONFIG REQUIRED)
 message(STATUS "${MKL_IMPORTED_TARGETS}") #Provides available list of targets based on input
 

--- a/recipe/tests/mkl-devel/CMakeLists.txt
+++ b/recipe/tests/mkl-devel/CMakeLists.txt
@@ -4,11 +4,20 @@ project(mkl_example LANGUAGES C)
 
 set(MKL_THREADING "intel_thread")
 
+# If any MKL component (even libiomp) is missing
+# cmake will error out. So REQUIRED is important for the test.
 find_package(MKL CONFIG REQUIRED)
 message(STATUS "${MKL_IMPORTED_TARGETS}") #Provides available list of targets based on input
 
 add_executable(myapp app.c)
 
 target_compile_options(myapp PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
+if (WIN32)
+    # https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/2021-8/use-the-openmp-libraries.html#id-d42745e610
+    target_compile_options(myapp PUBLIC "/openmp")
+    target_link_options(myapp PUBLIC "/nodefaultlib:vcomp")
+else
+    target_compile_options(myapp PUBLIC "-fopenmp")
+endif
 target_include_directories(myapp PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(myapp PUBLIC $<LINK_ONLY:MKL::MKL>)

--- a/recipe/tests/mkl-devel/CMakeLists.txt
+++ b/recipe/tests/mkl-devel/CMakeLists.txt
@@ -1,7 +1,5 @@
 cmake_minimum_required(VERSION 3.13)
 
-enable_testing()
-
 project(mkl_example LANGUAGES C)
 
 set(MKL_THREADING "intel_thread")
@@ -14,5 +12,3 @@ add_executable(myapp app.c)
 target_compile_options(myapp PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
 target_include_directories(myapp PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(myapp PUBLIC $<LINK_ONLY:MKL::MKL>)
-
-add_test(NAME mytest COMMAND myapp)

--- a/recipe/tests/mkl-devel/CMakeLists.txt
+++ b/recipe/tests/mkl-devel/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.13)
+
+enable_testing()
+
+project(mkl_example LANGUAGES C)
+
+find_package(MKL CONFIG REQUIRED)
+message(STATUS "${MKL_IMPORTED_TARGETS}") #Provides available list of targets based on input
+
+add_executable(myapp app.c)
+
+target_compile_options(myapp PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_COMPILE_OPTIONS>)
+target_include_directories(myapp PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
+target_link_libraries(myapp PUBLIC $<LINK_ONLY:MKL::MKL>)
+
+add_test(NAME mytest COMMAND myapp)

--- a/recipe/tests/mkl-devel/CMakeLists.txt
+++ b/recipe/tests/mkl-devel/CMakeLists.txt
@@ -16,8 +16,8 @@ if (WIN32)
     # https://www.intel.com/content/www/us/en/docs/cpp-compiler/developer-guide-reference/2021-8/use-the-openmp-libraries.html#id-d42745e610
     target_compile_options(myapp PUBLIC "/openmp")
     target_link_options(myapp PUBLIC "/nodefaultlib:vcomp")
-else
+else()
     target_compile_options(myapp PUBLIC "-fopenmp")
-endif
+endif()
 target_include_directories(myapp PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(myapp PUBLIC $<LINK_ONLY:MKL::MKL>)

--- a/recipe/tests/mkl-devel/CMakeLists.txt
+++ b/recipe/tests/mkl-devel/CMakeLists.txt
@@ -19,5 +19,14 @@ if (WIN32)
 else()
     target_compile_options(myapp PUBLIC "-fopenmp")
 endif()
+
+if (APPLE)
+    # Fixes this error:
+    # dyld: Symbol not found: _mkl_blas_caxpy
+    #   Referenced from: /Users/builder/...d_pla/lib/libmkl_intel_ilp64.2.dylib
+    #   Expected in: flat namespace in /Users/builder/jcmorin/miniconda/conda-bld/intel_r...d_pla/lib/libmkl_intel_ilp64.2.dylib
+    target_link_options(myapp PUBLIC "-Wl,-flat_namespace")
+endif()
+
 target_include_directories(myapp PUBLIC $<TARGET_PROPERTY:MKL::MKL,INTERFACE_INCLUDE_DIRECTORIES>)
 target_link_libraries(myapp PUBLIC $<LINK_ONLY:MKL::MKL>)

--- a/recipe/tests/mkl-devel/app.c
+++ b/recipe/tests/mkl-devel/app.c
@@ -1,5 +1,7 @@
+#include <stdio.h>
 #include <mkl.h>
-int main(void) {
+
+void main(void) {
     int my_cbwr_branch;
     /* Align all input/output data on 64-byte boundaries */
     /* "for best performance of Intel® oneAPI Math Kernel Library */

--- a/recipe/tests/mkl-devel/app.c
+++ b/recipe/tests/mkl-devel/app.c
@@ -1,7 +1,12 @@
 #include <stdio.h>
 #include <mkl.h>
+#include <omp.h>
 
 int main(void) {
     printf("MKL max threads: %d\n", mkl_get_max_threads());
+    #pragma omp parallel
+    {
+        printf("OpenMP: Hello from thread #%d\n", omp_get_thread_num());
+    }
     return 0;
 }

--- a/recipe/tests/mkl-devel/app.c
+++ b/recipe/tests/mkl-devel/app.c
@@ -1,28 +1,7 @@
 #include <stdio.h>
 #include <mkl.h>
 
-void main(void) {
-    int my_cbwr_branch;
-    /* Align all input/output data on 64-byte boundaries */
-    /* "for best performance of Intel® oneAPI Math Kernel Library */
-    void *darray;
-    int darray_size=1000;
-    /* Set alignment value in bytes */
-    int alignment=64;
-    /* Allocate aligned array */
-    darray = mkl_malloc (sizeof(double)*darray_size, alignment);
-    /* Find the available MKL_CBWR_BRANCH automatically */
-    my_cbwr_branch = mkl_cbwr_get_auto_branch();
-    /* User code without oneMKL calls */
-    /* Piece of the code where CNR of oneMKL is needed */
-    /* The performance of oneMKL functions might be reduced for CNR mode */
-    /* If the "IF" statement below is commented out, Intel® oneAPI Math Kernel Library will run in a regular mode, */
-    /* and data alignment will allow you to get best performance */
-    if (mkl_cbwr_set(my_cbwr_branch)) {
-        printf("Error in setting MKL_CBWR_BRANCH! Aborting…\n");
-        return;
-    }
-    /* CNR calls to oneMKL + any other code */
-    /* Free the allocated aligned array */
-    mkl_free(darray);
+int main(void) {
+    printf("MKL max threads: %d\n", mkl_get_max_threads());
+    return 0;
 }

--- a/recipe/tests/mkl-devel/app.c
+++ b/recipe/tests/mkl-devel/app.c
@@ -1,0 +1,26 @@
+#include <mkl.h>
+int main(void) {
+    int my_cbwr_branch;
+    /* Align all input/output data on 64-byte boundaries */
+    /* "for best performance of Intel® oneAPI Math Kernel Library */
+    void *darray;
+    int darray_size=1000;
+    /* Set alignment value in bytes */
+    int alignment=64;
+    /* Allocate aligned array */
+    darray = mkl_malloc (sizeof(double)*darray_size, alignment);
+    /* Find the available MKL_CBWR_BRANCH automatically */
+    my_cbwr_branch = mkl_cbwr_get_auto_branch();
+    /* User code without oneMKL calls */
+    /* Piece of the code where CNR of oneMKL is needed */
+    /* The performance of oneMKL functions might be reduced for CNR mode */
+    /* If the "IF" statement below is commented out, Intel® oneAPI Math Kernel Library will run in a regular mode, */
+    /* and data alignment will allow you to get best performance */
+    if (mkl_cbwr_set(my_cbwr_branch)) {
+        printf("Error in setting MKL_CBWR_BRANCH! Aborting…\n");
+        return;
+    }
+    /* CNR calls to oneMKL + any other code */
+    /* Free the allocated aligned array */
+    mkl_free(darray);
+}


### PR DESCRIPTION
Generate an [import library](https://learn.microsoft.com/en-us/windows/win32/dlls/dynamic-link-library-creation#creating-an-import-library) for `libiomp5md.dll` on Windows since Intel doesn't provide it and also patch the `MKLConfig.cmake` find package config provided by Intel since it's broken when used with conda packages. I added a test to make sure that it works as expected.