### PR TITLE
Add _openmp_mutex

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
+staging_channel_upload_target: openmp-mutex-rework-2
+
 channels:
-  - build
+  - https://staging.continuum.io/pbp/fs/_openmp_mutex-feedstock/pr2/6bb2abb
+  - https://staging.continuum.io/pbp/openmp-mutex-rework-2

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,0 @@
-staging_channel_upload_target: openmp-mutex-rework-4
-
-channels:
-  - https://staging.continuum.io/pbp/openmp-mutex-rework-4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,4 @@
-staging_channel_upload_target: openmp-mutex-rework-3
+staging_channel_upload_target: openmp-mutex-rework-4
 
 channels:
-  - https://staging.continuum.io/pbp/fs/_openmp_mutex-feedstock/pr2/6bb2abb
-  - https://staging.continuum.io/pbp/openmp-mutex-rework-3
+  - https://staging.continuum.io/pbp/openmp-mutex-rework-4

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
-# Override the default config.yaml's build_parameters to remove "--skip-existing" since `blas-1.0-mkl.*` will already exist.
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"
+channels:
+  - build

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,5 @@
-staging_channel_upload_target: openmp-mutex-rework-2
+staging_channel_upload_target: openmp-mutex-rework-3
 
 channels:
   - https://staging.continuum.io/pbp/fs/_openmp_mutex-feedstock/pr2/6bb2abb
-  - https://staging.continuum.io/pbp/openmp-mutex-rework-2
+  - https://staging.continuum.io/pbp/openmp-mutex-rework-3

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 # use this if our build script changes and we need to increment beyond intel's version
-{% set dstbuildnum = '2' %}
+{% set dstbuildnum = '3' %}
 
 # this variable defines oneMKL specific version
 {% set mkl_version = "2025.0.0" %}
@@ -188,6 +188,9 @@ outputs:
     version: {{ openmp_version }}
     build:
       number: {{ openmp_buildnum|int + dstbuildnum|int }}
+      run_exports:
+        strong:
+          - _openmp_mutex >=6.0 *_intel
       missing_dso_whitelist:
         # OS specific:
         - "/lib64/libelf.so.1"            # [linux] - OS file.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -192,7 +192,7 @@ outputs:
       number: {{ openmp_buildnum|int + dstbuildnum|int }}
       run_exports:
         strong:
-          - _openmp_mutex *_intel
+          - _openmp_mutex * *_intel
       missing_dso_whitelist:
         # OS specific:
         - "/lib64/libelf.so.1"            # [linux] - OS file.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -148,6 +148,8 @@ outputs:
         # various downstreams (mkl_fft, mkl_random) to include the mkl-service wrapper as a dependency.
         - mkl-service >=2.3.0,<3.0a0
     requirements:
+      build:
+        - msys2-sed  # [win]
       run:
         - {{ pin_subpackage('mkl', exact=True) }}
         - {{ pin_subpackage('mkl-include', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -225,10 +225,6 @@ outputs:
       host:
         - intel-cmplr-lib-ur {{ openmp_version.split('.')[0] }}.*
       run_constrained:
-        # prevent clobbering if user tries to install llvm's implementation
-        # TODO: use intel mutex or build windows torch in conda-froge
-        # https://github.com/conda-forge/intel-graphics-compiler-feedstock/pull/59
-        - llvm-openmp <0a0
         - __glibc >=2.26   # [linux] - intel-openmp 2025.0.0 and newer is built with a newer GLIBC
     # An empty requirements/build to satisfy anaconda-linter.
     requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -192,7 +192,7 @@ outputs:
       number: {{ openmp_buildnum|int + dstbuildnum|int }}
       run_exports:
         strong:
-          - _openmp_mutex >=6.0 *_intel
+          - _openmp_mutex *_intel
       missing_dso_whitelist:
         # OS specific:
         - "/lib64/libelf.so.1"            # [linux] - OS file.


### PR DESCRIPTION
intel_repack rebuild

**Destination channel:** defaults

### Links

- [PKG-14395](https://anaconda.atlassian.net/browse/PKG-14395) 

### Explanation of changes:

Update `intel-openmp` to participate in the external `_openmp_mutex` scheme by exporting the Intel mutex variant:
- `_openmp_mutex * *_intel`
This makes `intel-openmp` select the Intel OpenMP runtime family when installed, preventing it from being solved into the same environment as packages that require the GNU, LLVM, or MSVC OpenMP mutex variants.

#### Changes
- Add a strong `run_exports` dependency from `intel-openmp` to `_openmp_mutex * *_intel`.
- Bump the repack build number so the updated metadata is published.
- Add `msys2-sed` as a Windows build dependency for the `mkl-devel` output.


[PKG-13452]: https://anaconda.atlassian.net/browse/PKG-13452?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-14395]: https://anaconda.atlassian.net/browse/PKG-14395?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ